### PR TITLE
Sre 1476/fix missing dashboards

### DIFF
--- a/charts/bluescape-monitoring-dashboards/Chart.yaml
+++ b/charts/bluescape-monitoring-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.17
+version: 0.2.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-monitoring-dashboards/templates/83_document_upload_metrics/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/83_document_upload_metrics/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
 data:
-  template-dashboard.json: |-
+  gen3-document-upload-metrics-dashboard.json: |-
     {
       "annotations": {
         "list": [

--- a/charts/bluescape-monitoring-dashboards/templates/90_all-nodes/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/90_all-nodes/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: all-nodes
+  name: all-nodes-dashboard
   namespace: grafana
   labels:
     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}

--- a/charts/bluescape-monitoring-dashboards/templates/94_synthetic_tests/dashboard.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/94_synthetic_tests/dashboard.yaml
@@ -1,12 +1,12 @@
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
-  name:  syntheti-test-dashboard
+  name:  synthetic-test-dashboard
   namespace: grafana
   labels:
     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
 spec:
-  name:  syntheti-test-dashboard
+  name:  synthetic-test-dashboard
   configMapRef:
-    name:  syntheti-test-dashboard
-    key:  syntheti-test-dashboard.json
+    name:  synthetic-test-dashboard
+    key:  synthetic-test-dashboard.json


### PR DESCRIPTION
Fix missing dashboards

- Self-Serve Dashboard
- Analytics Dashbaord

There were some typos in other dashboards and this is the fix to make sure all the missing dashboards are deployed successfully.