### PR TITLE
NEX-2046 - Adding capability to use old and new api version for cert-manager issuer

### DIFF
--- a/charts/bluescape-eks-aux/CHANGELOG.md
+++ b/charts/bluescape-eks-aux/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2017-06-20 - NEX-2048
 ### Changed
-- cert-manager cluster issuer api version updated to "v1" on all cluster issuers
-- requires new updated cert-manager version 1.8.2
+- cert-manager cluster issuers api version is now dynamic that supports the old and new api versions
 
 ## [0.9.0] 
 ### Added

--- a/charts/bluescape-eks-aux/CHANGELOG.md
+++ b/charts/bluescape-eks-aux/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.10.0] - 2017-06-20 - NEX-2048
+### Changed
+- cert-manager cluster issuer api version updated to "v1" on all cluster issuers
+- requires new updated cert-manager version 1.8.2
+
+## [0.9.0] 
+### Added
+- new changelog

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0-alpha2
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0-alpha1
+version: 0.10.0-alpha2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-extra.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-extra.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.enabled }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: ClusterIssuer
 metadata:
   name:   "{{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.name }}"

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-extra.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-extra.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name:   "{{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.name }}"

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod-dns.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod-dns.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.cert_manager.setup_letsencrypt_prod_cluster_dns_issuer }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: ClusterIssuer
 metadata:
   name:   "letsencrypt-prod-dns"

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod-dns.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod-dns.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cert_manager.setup_letsencrypt_prod_cluster_dns_issuer }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name:   "letsencrypt-prod-dns"

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cert_manager.setup_letsencrypt_prod_cluster_issuer }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: "letsencrypt-prod"

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-prod.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.cert_manager.setup_letsencrypt_prod_cluster_issuer }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
+{{- else }}
+apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: ClusterIssuer
 metadata:
   name: "letsencrypt-prod"


### PR DESCRIPTION
Adding capability to use old and new api version for cert-manager issuer

Tested manually on a-neb cluster successfully

Notes:
This is to support the new cert-manager version 1.8.2