### PR TITLE
NEX-2139 - Updates to support AES 3.1 CRDs

### DIFF
--- a/charts/bluescape-emissary-crds/Chart.yaml
+++ b/charts/bluescape-emissary-crds/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-emissary-crds/crds/aes-crds.yaml
+++ b/charts/bluescape-emissary-crds/crds/aes-crds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.version == "2" }}
 # GENERATED FILE: edits made by hand will not be preserved.
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5569,3 +5570,4 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 3
             failureThreshold: 3
+{{- end }}

--- a/charts/bluescape-emissary-crds/crds/aes-creds-3_1.yaml
+++ b/charts/bluescape-emissary-crds/crds/aes-creds-3_1.yaml
@@ -1,0 +1,5673 @@
+{{- if .Values.version == "3" }}
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: filterpolicies.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: FilterPolicy
+    listKind: FilterPolicyList
+    plural: filterpolicies
+    shortNames:
+      - fp
+    singular: filterpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                rules:
+                  items:
+                    description: Rule defines authorization rules object.
+                    properties:
+                      filters:
+                        items:
+                          properties:
+                            arguments:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            ifRequestHeader:
+                              properties:
+                                name:
+                                  type: string
+                                negate:
+                                  type: boolean
+                                value:
+                                  type: string
+                                valueRegex:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            onAllow:
+                              type: string
+                            onDeny:
+                              type: string
+                          type: object
+                        type: array
+                      host:
+                        type: string
+                      path:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                rules:
+                  items:
+                    description: Rule defines authorization rules object.
+                    properties:
+                      filters:
+                        items:
+                          properties:
+                            arguments:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            ifRequestHeader:
+                              properties:
+                                name:
+                                  type: string
+                                negate:
+                                  type: boolean
+                                value:
+                                  type: string
+                                valueRegex:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            onAllow:
+                              type: string
+                            onDeny:
+                              type: string
+                          type: object
+                        type: array
+                      host:
+                        type: string
+                      path:
+                        type: string
+                      v3Precedence:
+                        type: integer
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                rules:
+                  items:
+                    description: Rule defines authorization rules object.
+                    properties:
+                      filters:
+                        items:
+                          properties:
+                            arguments:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            ifRequestHeader:
+                              properties:
+                                name:
+                                  type: string
+                                negate:
+                                  type: boolean
+                                value:
+                                  type: string
+                                valueRegex:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            onAllow:
+                              type: string
+                            onDeny:
+                              type: string
+                          type: object
+                        type: array
+                      host:
+                        type: string
+                      path:
+                        type: string
+                      precedence:
+                        type: integer
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: filters.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: Filter
+    listKind: FilterList
+    plural: filters
+    shortNames:
+      - fil
+    singular: filter
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                External:
+                  description: FilterExternal closely mimics AuthService.getambassador.io.
+                  properties:
+                    add_linkerd_headers:
+                      type: boolean
+                    allow_request_body:
+                      type: boolean
+                    allowed_authorization_headers:
+                      items:
+                        type: string
+                      type: array
+                    allowed_request_headers:
+                      items:
+                        type: string
+                      type: array
+                    auth_service:
+                      type: string
+                    failure_mode_allow:
+                      type: boolean
+                    include_body:
+                      properties:
+                        allow_partial:
+                          type: boolean
+                        max_bytes:
+                          type: integer
+                      type: object
+                    path_prefix:
+                      type: string
+                    proto:
+                      enum:
+                        - http
+                        - grpc
+                      type: string
+                    status_on_error:
+                      properties:
+                        code:
+                          type: integer
+                      type: object
+                    timeout_ms:
+                      description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                      fields to `{foo}`/`metav1.Duration`.'
+                      type: integer
+                    tls:
+                      description: Emissary supports setting "tls" to the name of a
+                        TLSContext.  Edge Stack External Filters do NOT yet support
+                        that; in External Filters "tls" is a boolean indicating whether
+                        to originate TLS.
+                      type: boolean
+                  required:
+                    - auth_service
+                  type: object
+                JWT:
+                  description: "FilterJWT \n Currently supported algorithms: \n - RSA
+                  \  * \"RS256\"   * \"RS384\"   * \"RS512\" - RSA-PSS   * \"PS256\"
+                  \  * \"PS384\"   * \"PS512\" - ECDSA   * \"ES256\"   * \"ES384\"
+                  \  * \"ES512\" - HMAC-SHA   * \"HS256\"   * \"HS384\"   * \"HS512\"
+                  - \"none\" \n This is this list of algos built-in to github.com/dgrijalva/jwt-go
+                  v3.2.0.  Keep this list in sync if we pull in a jwt-go update. More
+                  algorithms can be added with jwt.RegistersigningMethod(). \n Haha,
+                  JK, our JWKS parser only understands RSA keys."
+                  properties:
+                    audience:
+                      type: string
+                    errorResponse:
+                      properties:
+                        bodyTemplate:
+                          type: string
+                        contentType:
+                          type: string
+                        headers:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        realm:
+                          type: string
+                      type: object
+                    injectRequestHeaders:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    insecureTLS:
+                      type: boolean
+                    issuer:
+                      type: string
+                    jwksURI:
+                      type: string
+                    leewayForExpiresAt:
+                      type: string
+                    leewayForIssuedAt:
+                      type: string
+                    leewayForNotBefore:
+                      type: string
+                    renegotiateTLS:
+                      enum:
+                        - never
+                        - onceAsClient
+                        - freelyAsClient
+                      type: string
+                    requireAudience:
+                      type: boolean
+                    requireExpiresAt:
+                      type: boolean
+                    requireIssuedAt:
+                      type: boolean
+                    requireIssuer:
+                      type: boolean
+                    requireNotBefore:
+                      type: boolean
+                    v3MaxStale:
+                      type: string
+                    validAlgorithms:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                OAuth2:
+                  properties:
+                    accessTokenJWTFilter:
+                      properties:
+                        arguments:
+                          properties:
+                            scope:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        inheritScopeArgument:
+                          type: boolean
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        stripInheritedScope:
+                          type: boolean
+                      type: object
+                    accessTokenValidation:
+                      type: string
+                    allowMalformedAccessToken:
+                      type: boolean
+                    audience:
+                      type: string
+                    authorizationURL:
+                      type: string
+                    clientAuthentication:
+                      properties:
+                        jwtAssertion:
+                          properties:
+                            audience:
+                              type: string
+                            lifetime:
+                              type: string
+                            nbfSafetyMargin:
+                              type: string
+                            otherClaims:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            otherHeaderParameters:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            setClientID:
+                              type: boolean
+                            setIAT:
+                              type: boolean
+                            setNBF:
+                              type: boolean
+                            signingMethod:
+                              enum:
+                                - ES256
+                                - ES384
+                                - ES512
+                                - HS256
+                                - HS384
+                                - HS512
+                                - PS256
+                                - PS384
+                                - PS512
+                                - RS256
+                                - RS384
+                                - RS512
+                                - none
+                              type: string
+                          type: object
+                        method:
+                          enum:
+                            - ""
+                            - HeaderPassword
+                            - BodyPassword
+                            - JWTAssertion
+                          type: string
+                      type: object
+                    clientID:
+                      type: string
+                    clientURL:
+                      type: string
+                    expirationSafetyMargin:
+                      type: string
+                    extraAuthorizationParameters:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    grantType:
+                      type: string
+                    injectRequestHeaders:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    insecureTLS:
+                      type: boolean
+                    maxStale:
+                      type: string
+                    protectedOrigins:
+                      items:
+                        properties:
+                          includeSubdomains:
+                            type: boolean
+                          internalOrigin:
+                            type: string
+                          origin:
+                            type: string
+                        type: object
+                      type: array
+                    renegotiateTLS:
+                      enum:
+                        - never
+                        - onceAsClient
+                        - freelyAsClient
+                      type: string
+                    secret:
+                      type: string
+                    secretName:
+                      type: string
+                    secretNamespace:
+                      type: string
+                    stateTTL:
+                      type: string
+                    useSessionCookies:
+                      properties:
+                        ifRequestHeader:
+                          properties:
+                            name:
+                              type: string
+                            negate:
+                              type: boolean
+                            value:
+                              type: string
+                            valueRegex:
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        value:
+                          type: boolean
+                      type: object
+                  type: object
+                Plugin:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                External:
+                  description: FilterExternal closely mimics AuthService.getambassador.io.
+                  properties:
+                    add_linkerd_headers:
+                      type: boolean
+                    allow_request_body:
+                      type: boolean
+                    allowed_authorization_headers:
+                      items:
+                        type: string
+                      type: array
+                    allowed_request_headers:
+                      items:
+                        type: string
+                      type: array
+                    auth_service:
+                      type: string
+                    failure_mode_allow:
+                      type: boolean
+                    include_body:
+                      properties:
+                        allow_partial:
+                          type: boolean
+                        max_bytes:
+                          type: integer
+                      type: object
+                    path_prefix:
+                      type: string
+                    proto:
+                      enum:
+                        - http
+                        - grpc
+                      type: string
+                    status_on_error:
+                      properties:
+                        code:
+                          type: integer
+                      type: object
+                    timeout_ms:
+                      description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                      fields to `{foo}`/`metav1.Duration`.'
+                      type: integer
+                    tls:
+                      description: Emissary supports setting "tls" to the name of a
+                        TLSContext.  Edge Stack External Filters do NOT yet support
+                        that; in External Filters "tls" is a boolean indicating whether
+                        to originate TLS.
+                      type: boolean
+                    v3ProtocolVersion:
+                      enum:
+                        - v2
+                        - v3
+                      type: string
+                  required:
+                    - auth_service
+                  type: object
+                JWT:
+                  description: "FilterJWT \n Currently supported algorithms: \n - RSA
+                  \  * \"RS256\"   * \"RS384\"   * \"RS512\" - RSA-PSS   * \"PS256\"
+                  \  * \"PS384\"   * \"PS512\" - ECDSA   * \"ES256\"   * \"ES384\"
+                  \  * \"ES512\" - HMAC-SHA   * \"HS256\"   * \"HS384\"   * \"HS512\"
+                  - \"none\" \n This is this list of algos built-in to github.com/dgrijalva/jwt-go
+                  v3.2.0.  Keep this list in sync if we pull in a jwt-go update. More
+                  algorithms can be added with jwt.RegistersigningMethod(). \n Haha,
+                  JK, our JWKS parser only understands RSA keys."
+                  properties:
+                    audience:
+                      type: string
+                    errorResponse:
+                      properties:
+                        bodyTemplate:
+                          type: string
+                        contentType:
+                          type: string
+                        headers:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        realm:
+                          type: string
+                      type: object
+                    injectRequestHeaders:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    insecureTLS:
+                      type: boolean
+                    issuer:
+                      type: string
+                    jwksURI:
+                      type: string
+                    leewayForExpiresAt:
+                      type: string
+                    leewayForIssuedAt:
+                      type: string
+                    leewayForNotBefore:
+                      type: string
+                    renegotiateTLS:
+                      enum:
+                        - never
+                        - onceAsClient
+                        - freelyAsClient
+                      type: string
+                    requireAudience:
+                      type: boolean
+                    requireExpiresAt:
+                      type: boolean
+                    requireIssuedAt:
+                      type: boolean
+                    requireIssuer:
+                      type: boolean
+                    requireNotBefore:
+                      type: boolean
+                    v3MaxStale:
+                      type: string
+                    validAlgorithms:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                OAuth2:
+                  properties:
+                    accessTokenJWTFilter:
+                      properties:
+                        arguments:
+                          properties:
+                            scope:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        inheritScopeArgument:
+                          type: boolean
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        stripInheritedScope:
+                          type: boolean
+                      type: object
+                    accessTokenValidation:
+                      type: string
+                    allowMalformedAccessToken:
+                      type: boolean
+                    audience:
+                      type: string
+                    authorizationURL:
+                      type: string
+                    clientAuthentication:
+                      properties:
+                        jwtAssertion:
+                          properties:
+                            audience:
+                              type: string
+                            lifetime:
+                              type: string
+                            nbfSafetyMargin:
+                              type: string
+                            otherClaims:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            otherHeaderParameters:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            setClientID:
+                              type: boolean
+                            setIAT:
+                              type: boolean
+                            setNBF:
+                              type: boolean
+                            signingMethod:
+                              enum:
+                                - ES256
+                                - ES384
+                                - ES512
+                                - HS256
+                                - HS384
+                                - HS512
+                                - PS256
+                                - PS384
+                                - PS512
+                                - RS256
+                                - RS384
+                                - RS512
+                                - none
+                              type: string
+                          type: object
+                        method:
+                          enum:
+                            - ""
+                            - HeaderPassword
+                            - BodyPassword
+                            - JWTAssertion
+                          type: string
+                      type: object
+                    clientID:
+                      type: string
+                    clientURL:
+                      type: string
+                    expirationSafetyMargin:
+                      type: string
+                    extraAuthorizationParameters:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    grantType:
+                      type: string
+                    injectRequestHeaders:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    insecureTLS:
+                      type: boolean
+                    maxStale:
+                      type: string
+                    protectedOrigins:
+                      items:
+                        properties:
+                          includeSubdomains:
+                            type: boolean
+                          internalOrigin:
+                            type: string
+                          origin:
+                            type: string
+                        type: object
+                      type: array
+                    renegotiateTLS:
+                      enum:
+                        - never
+                        - onceAsClient
+                        - freelyAsClient
+                      type: string
+                    secret:
+                      type: string
+                    secretName:
+                      type: string
+                    secretNamespace:
+                      type: string
+                    stateTTL:
+                      type: string
+                    useSessionCookies:
+                      properties:
+                        ifRequestHeader:
+                          properties:
+                            name:
+                              type: string
+                            negate:
+                              type: boolean
+                            value:
+                              type: string
+                            valueRegex:
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        value:
+                          type: boolean
+                      type: object
+                  type: object
+                Plugin:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                v3APIKey:
+                  description: FilterAPIKey enforce a set of API Keys.
+                  properties:
+                    httpHeader:
+                      type: string
+                    keys:
+                      items:
+                        description: APIKeyItem defines how to resolve the values of
+                          the keys.
+                        properties:
+                          secretName:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                    - keys
+                  type: object
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                APIKey:
+                  description: FilterAPIKey enforce a set of API Keys.
+                  properties:
+                    httpHeader:
+                      type: string
+                    keys:
+                      items:
+                        description: APIKeyItem defines how to resolve the values of
+                          the keys.
+                        properties:
+                          secretName:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                    - keys
+                  type: object
+                External:
+                  description: FilterExternal closely mimics AuthService.getambassador.io.
+                  properties:
+                    add_linkerd_headers:
+                      type: boolean
+                    allow_request_body:
+                      type: boolean
+                    allowed_authorization_headers:
+                      items:
+                        type: string
+                      type: array
+                    allowed_request_headers:
+                      items:
+                        type: string
+                      type: array
+                    auth_service:
+                      type: string
+                    failure_mode_allow:
+                      type: boolean
+                    include_body:
+                      properties:
+                        allow_partial:
+                          type: boolean
+                        max_bytes:
+                          type: integer
+                      type: object
+                    path_prefix:
+                      type: string
+                    proto:
+                      enum:
+                        - http
+                        - grpc
+                      type: string
+                    protocol_version:
+                      enum:
+                        - v2
+                        - v3
+                      type: string
+                    status_on_error:
+                      description: 'TODO(lukeshu): In v3alpha2, consider getting rid
+                      of this struct type in favor of just using an int (i.e. `statusOnError:
+                      500` instead of the current `statusOnError: { code: 500 }`).'
+                      properties:
+                        code:
+                          type: integer
+                      type: object
+                    timeout_ms:
+                      description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                      fields to `{foo}`/`metav1.Duration`.'
+                      type: integer
+                    tls:
+                      description: Emissary supports setting "tls" to the name of a
+                        TLSContext.  Edge Stack External Filters do NOT yet support
+                        that; in External Filters "tls" is a boolean indicating whether
+                        to originate TLS.
+                      type: boolean
+                  required:
+                    - auth_service
+                  type: object
+                JWT:
+                  description: "FilterJWT \n Currently supported algorithms: \n - RSA
+                  \  * \"RS256\"   * \"RS384\"   * \"RS512\" - RSA-PSS   * \"PS256\"
+                  \  * \"PS384\"   * \"PS512\" - ECDSA   * \"ES256\"   * \"ES384\"
+                  \  * \"ES512\" - HMAC-SHA   * \"HS256\"   * \"HS384\"   * \"HS512\"
+                  - \"none\" \n This is this list of algos built-in to github.com/dgrijalva/jwt-go
+                  v3.2.0.  Keep this list in sync if we pull in a jwt-go update. More
+                  algorithms can be added with jwt.RegistersigningMethod(). \n Haha,
+                  JK, our JWKS parser only understands RSA keys."
+                  properties:
+                    audience:
+                      type: string
+                    errorResponse:
+                      properties:
+                        bodyTemplate:
+                          type: string
+                        contentType:
+                          type: string
+                        headers:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        realm:
+                          type: string
+                      type: object
+                    injectRequestHeaders:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    insecureTLS:
+                      type: boolean
+                    issuer:
+                      type: string
+                    jwksURI:
+                      type: string
+                    leewayForExpiresAt:
+                      type: string
+                    leewayForIssuedAt:
+                      type: string
+                    leewayForNotBefore:
+                      type: string
+                    maxStale:
+                      type: string
+                    renegotiateTLS:
+                      enum:
+                        - never
+                        - onceAsClient
+                        - freelyAsClient
+                      type: string
+                    requireAudience:
+                      type: boolean
+                    requireExpiresAt:
+                      type: boolean
+                    requireIssuedAt:
+                      type: boolean
+                    requireIssuer:
+                      type: boolean
+                    requireNotBefore:
+                      type: boolean
+                    validAlgorithms:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                OAuth2:
+                  properties:
+                    accessTokenJWTFilter:
+                      properties:
+                        arguments:
+                          properties:
+                            scope:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        inheritScopeArgument:
+                          type: boolean
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        stripInheritedScope:
+                          type: boolean
+                      type: object
+                    accessTokenValidation:
+                      type: string
+                    allowMalformedAccessToken:
+                      type: boolean
+                    audience:
+                      type: string
+                    authorizationURL:
+                      type: string
+                    clientAuthentication:
+                      properties:
+                        jwtAssertion:
+                          properties:
+                            audience:
+                              type: string
+                            lifetime:
+                              type: string
+                            nbfSafetyMargin:
+                              type: string
+                            otherClaims:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            otherHeaderParameters:
+                              description: UntypedDict is relatively opaque as a Go
+                                type, but it preserves its contents in a roundtrippable
+                                way.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            setClientID:
+                              type: boolean
+                            setIAT:
+                              type: boolean
+                            setNBF:
+                              type: boolean
+                            signingMethod:
+                              enum:
+                                - ES256
+                                - ES384
+                                - ES512
+                                - HS256
+                                - HS384
+                                - HS512
+                                - PS256
+                                - PS384
+                                - PS512
+                                - RS256
+                                - RS384
+                                - RS512
+                                - none
+                              type: string
+                          type: object
+                        method:
+                          enum:
+                            - ""
+                            - HeaderPassword
+                            - BodyPassword
+                            - JWTAssertion
+                          type: string
+                      type: object
+                    clientID:
+                      type: string
+                    clientURL:
+                      type: string
+                    expirationSafetyMargin:
+                      type: string
+                    extraAuthorizationParameters:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    grantType:
+                      type: string
+                    injectRequestHeaders:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    insecureTLS:
+                      type: boolean
+                    maxStale:
+                      type: string
+                    protectedOrigins:
+                      items:
+                        properties:
+                          includeSubdomains:
+                            type: boolean
+                          internalOrigin:
+                            type: string
+                          origin:
+                            type: string
+                        type: object
+                      type: array
+                    renegotiateTLS:
+                      enum:
+                        - never
+                        - onceAsClient
+                        - freelyAsClient
+                      type: string
+                    secret:
+                      type: string
+                    secretName:
+                      type: string
+                    secretNamespace:
+                      type: string
+                    stateTTL:
+                      type: string
+                    useSessionCookies:
+                      properties:
+                        ifRequestHeader:
+                          properties:
+                            name:
+                              type: string
+                            negate:
+                              type: boolean
+                            value:
+                              type: string
+                            valueRegex:
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        value:
+                          type: boolean
+                      type: object
+                  type: object
+                Plugin:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: ratelimits.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: RateLimit
+    listKind: RateLimitList
+    plural: ratelimits
+    shortNames:
+      - rl
+    singular: ratelimit
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                domain:
+                  type: string
+                limits:
+                  items:
+                    properties:
+                      action:
+                        pattern: ^([eE][nN][fF][oO][rR][cC][eE]|[lL][oO][gG][oO][nN][lL][yY])$
+                        type: string
+                      burstFactor:
+                        format: int32
+                        type: integer
+                      errorResponse:
+                        properties:
+                          bodyTemplate:
+                            type: string
+                          contentType:
+                            type: string
+                          headers:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          realm:
+                            type: string
+                        type: object
+                      injectRequestHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      injectResponseHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                      pattern:
+                        items:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        type: array
+                      rate:
+                        format: int32
+                        type: integer
+                      unit:
+                        pattern: ^([uU][nN][kK][nN][oO][wW][nN]|[sS][eE][cC][oO][nN][dD]|[mM][iI][nN][uU][tT][eE]|[hH][oO][uU][rR]|[dD][aA][yY])$
+                        type: string
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                domain:
+                  type: string
+                limits:
+                  items:
+                    properties:
+                      action:
+                        pattern: ^([eE][nN][fF][oO][rR][cC][eE]|[lL][oO][gG][oO][nN][lL][yY])$
+                        type: string
+                      burstFactor:
+                        format: int32
+                        type: integer
+                      errorResponse:
+                        properties:
+                          bodyTemplate:
+                            type: string
+                          contentType:
+                            type: string
+                          headers:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          realm:
+                            type: string
+                        type: object
+                      injectRequestHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      injectResponseHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                      pattern:
+                        items:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        type: array
+                      rate:
+                        format: int32
+                        type: integer
+                      unit:
+                        pattern: ^([uU][nN][kK][nN][oO][wW][nN]|[sS][eE][cC][oO][nN][dD]|[mM][iI][nN][uU][tT][eE]|[hH][oO][uU][rR]|[dD][aA][yY])$
+                        type: string
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                domain:
+                  type: string
+                limits:
+                  items:
+                    properties:
+                      action:
+                        pattern: ^([eE][nN][fF][oO][rR][cC][eE]|[lL][oO][gG][oO][nN][lL][yY])$
+                        type: string
+                      burstFactor:
+                        format: int32
+                        type: integer
+                      errorResponse:
+                        properties:
+                          bodyTemplate:
+                            type: string
+                          contentType:
+                            type: string
+                          headers:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          realm:
+                            type: string
+                        type: object
+                      injectRequestHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      injectResponseHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                      pattern:
+                        items:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        type: array
+                      rate:
+                        format: int32
+                        type: integer
+                      unit:
+                        pattern: ^([uU][nN][kK][nN][oO][wW][nN]|[sS][eE][cC][oO][nN][dD]|[mM][iI][nN][uU][tT][eE]|[hH][oO][uU][rR]|[dD][aA][yY])$
+                        type: string
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                domain:
+                  type: string
+                limits:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Enforce
+                          - LogOnly
+                        type: string
+                      burstFactor:
+                        format: int32
+                        type: integer
+                      errorResponse:
+                        properties:
+                          bodyTemplate:
+                            type: string
+                          contentType:
+                            type: string
+                          headers:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          realm:
+                            type: string
+                        type: object
+                      injectRequestHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      injectResponseHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                      pattern:
+                        items:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        type: array
+                      rate:
+                        format: int32
+                        type: integer
+                      unit:
+                        pattern: ^([uU][nN][kK][nN][oO][wW][nN]|[sS][eE][cC][oO][nN][dD]|[mM][iI][nN][uU][tT][eE]|[hH][oO][uU][rR]|[dD][aA][yY])$
+                        type: string
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: authservices.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: AuthService
+    listKind: AuthServiceList
+    plural: authservices
+    singular: authservice
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: AuthService is the Schema for the authservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AuthServiceSpec defines the desired state of AuthService
+              properties:
+                add_auth_headers:
+                  additionalProperties:
+                    type: string
+                  type: object
+                add_linkerd_headers:
+                  type: boolean
+                allow_request_body:
+                  type: boolean
+                allowed_authorization_headers:
+                  items:
+                    type: string
+                  type: array
+                allowed_request_headers:
+                  items:
+                    type: string
+                  type: array
+                auth_service:
+                  type: string
+                failure_mode_allow:
+                  type: boolean
+                include_body:
+                  properties:
+                    allow_partial:
+                      type: boolean
+                    max_bytes:
+                      description: These aren't pointer types because they are required.
+                      type: integer
+                  required:
+                    - allow_partial
+                    - max_bytes
+                  type: object
+                path_prefix:
+                  type: string
+                proto:
+                  enum:
+                    - http
+                    - grpc
+                  type: string
+                protocol_version:
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                status_on_error:
+                  description: Why isn't this just an int??
+                  properties:
+                    code:
+                      type: integer
+                  type: object
+                timeout_ms:
+                  type: integer
+                v3CircuitBreakers:
+                  items:
+                    properties:
+                      max_connections:
+                        type: integer
+                      max_pending_requests:
+                        type: integer
+                      max_requests:
+                        type: integer
+                      max_retries:
+                        type: integer
+                      priority:
+                        enum:
+                          - default
+                          - high
+                        type: string
+                    type: object
+                  type: array
+                v3StatsName:
+                  type: string
+              required:
+                - auth_service
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: AuthService is the Schema for the authservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AuthServiceSpec defines the desired state of AuthService
+              properties:
+                add_auth_headers:
+                  additionalProperties:
+                    type: string
+                  type: object
+                add_linkerd_headers:
+                  type: boolean
+                allow_request_body:
+                  description: 'TODO(lukeshu): In v3alpha2, drop allow_request_body
+                  in favor of include_body. allow_request_body has been deprecated
+                  for a long time.'
+                  type: boolean
+                allowed_authorization_headers:
+                  items:
+                    type: string
+                  type: array
+                allowed_request_headers:
+                  items:
+                    type: string
+                  type: array
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                auth_service:
+                  description: 'TODO(lukeshu): In v3alpha2, consider renameing `auth_service`
+                  to just `service`, for consistency with the other resource types.'
+                  type: string
+                circuit_breakers:
+                  items:
+                    properties:
+                      max_connections:
+                        type: integer
+                      max_pending_requests:
+                        type: integer
+                      max_requests:
+                        type: integer
+                      max_retries:
+                        type: integer
+                      priority:
+                        enum:
+                          - default
+                          - high
+                        type: string
+                    type: object
+                  type: array
+                failure_mode_allow:
+                  type: boolean
+                include_body:
+                  properties:
+                    allow_partial:
+                      type: boolean
+                    max_bytes:
+                      description: These aren't pointer types because they are required.
+                      type: integer
+                  required:
+                    - allow_partial
+                    - max_bytes
+                  type: object
+                path_prefix:
+                  type: string
+                proto:
+                  enum:
+                    - http
+                    - grpc
+                  type: string
+                protocol_version:
+                  description: ProtocolVersion is the envoy api transport protocol version
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                stats_name:
+                  type: string
+                status_on_error:
+                  description: 'TODO(lukeshu): In v3alpha2, consider getting rid of
+                  this struct type in favor of just using an int (i.e. `statusOnError:
+                  500` instead of the current `statusOnError: { code: 500 }`).'
+                  properties:
+                    code:
+                      type: integer
+                  type: object
+                timeout_ms:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                tls:
+                  type: string
+                v2ExplicitTLS:
+                  description: V2ExplicitTLS controls some vanity/stylistic elements
+                    when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS
+                    should not in any way affect the runtime operation of Emissary;
+                    except that it may affect internal names in the Envoy config, which
+                    may in turn affect stats names.  But it should not affect any end-user
+                    observable behavior.
+                  properties:
+                    serviceScheme:
+                      description: "ServiceScheme specifies how to spell and capitalize
+                      the scheme-part of the service URL. \n Acceptable values are
+                      \"http://\" (case-insensitive), \"https://\" (case-insensitive),
+                      or \"\".  The value is used if it agrees with whether or not
+                      this resource enables TLS origination, or if something else
+                      in the resource overrides the scheme."
+                      pattern: ^([hH][tT][tT][pP][sS]?://)?$
+                      type: string
+                    tls:
+                      description: "TLS controls whether and how to represent the \"tls\"
+                      field when its value could be implied by the \"service\" field.
+                      \ In v2, there were a lot of different ways to spell an \"empty\"
+                      value, and this field specifies which way to spell it (and will
+                      therefore only be used if the value will indeed be empty). \n
+                      \ | Value        | Representation                        | Meaning
+                      of representation          |  |--------------+---------------------------------------+------------------------------------|
+                      \ | \"\"           | omit the field                        |
+                      defer to service (no TLSContext)   |  | \"null\"       | store
+                      an explicit \"null\" in the field | defer to service (no TLSContext)
+                      \  |  | \"string\"     | store an empty string in the field
+                      \   | defer to service (no TLSContext)   |  | \"bool:false\"
+                      | store a Boolean \"false\" in the field  | defer to service
+                      (no TLSContext)   |  | \"bool:true\"  | store a Boolean \"true\"
+                      in the field   | originate TLS (no TLSContext)      | \n If
+                      the meaning of the representation contradicts anything else
+                      (if a TLSContext is to be used, or in the case of \"bool:true\"
+                      if TLS is not to be originated), then this field is ignored."
+                      enum:
+                        - ""
+                        - "null"
+                        - bool:true
+                        - bool:false
+                        - string
+                      type: string
+                  type: object
+              required:
+                - auth_service
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: AuthService is the Schema for the authservices API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: consulresolvers.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: ConsulResolver
+    listKind: ConsulResolverList
+    plural: consulresolvers
+    singular: consulresolver
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: ConsulResolver is the Schema for the ConsulResolver API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConsulResolver tells Ambassador to use Consul to resolve
+                services. In addition to the AmbassadorID, it needs information about
+                which Consul server and DC to use.
+              properties:
+                address:
+                  type: string
+                datacenter:
+                  type: string
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: ConsulResolver is the Schema for the ConsulResolver API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConsulResolver tells Ambassador to use Consul to resolve
+                services. In addition to the AmbassadorID, it needs information about
+                which Consul server and DC to use.
+              properties:
+                address:
+                  type: string
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                datacenter:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ConsulResolver is the Schema for the ConsulResolver API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: devportals.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: DevPortal
+    listKind: DevPortalList
+    plural: devportals
+    singular: devportal
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: "DevPortal is the Schema for the DevPortals API \n DevPortal
+          resources specify the `what` and `how` is shown in a DevPortal: \n * `what`
+          is in a DevPortal can be controlled with   - a `selector`, that can be used
+          for filtering `Mappings`.   - a `docs` listing of (services, url) * `how`
+          is a pointer to some `contents` (a checkout of a Git repository   with go-templates/markdown/css).
+          \n Multiple `DevPortal`s can exist in the cluster, and the Dev Portal server
+          will show them at different endpoints. A `DevPortal` resource with a special
+          name, `ambassador`, will be used for configuring the default Dev Portal
+          (served at `/docs/` by default)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DevPortalSpec defines the desired state of DevPortal
+              properties:
+                content:
+                  description: Content specifies where the content shown in the DevPortal
+                    come from
+                  properties:
+                    branch:
+                      type: string
+                    dir:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                default:
+                  description: Default must be true when this is the default DevPortal
+                  type: boolean
+                docs:
+                  description: Docs is a static docs definition
+                  items:
+                    description: 'DevPortalDocsSpec is a static documentation definition:
+                    instead of using a Selector for finding documentation for services,
+                    users can provide a static list of <service>:<URL> tuples. These
+                    services will be shown in the Dev Portal with the documentation
+                    obtained from this URL.'
+                    properties:
+                      service:
+                        description: Service is the service being documented
+                        type: string
+                      timeout_ms:
+                        description: Timeout specifies the amount of time devportal
+                          will wait for the downstream service to report an openapi
+                          spec back
+                        type: integer
+                      url:
+                        description: URL is the URL used for obtaining docs
+                        type: string
+                    type: object
+                  type: array
+                naming_scheme:
+                  description: Describes how to display "services" in the DevPortal.
+                    Default namespace.name
+                  enum:
+                    - namespace.name
+                    - name.prefix
+                  type: string
+                preserve_servers:
+                  description: Configures this DevPortal to use server definitions from
+                    the openAPI doc instead of rewriting them based on the url used
+                    for the connection.
+                  type: boolean
+                search:
+                  description: DevPortalSearchSpec allows configuration over search
+                    functionality for the DevPortal
+                  properties:
+                    enabled:
+                      type: boolean
+                    type:
+                      description: 'Type of search. "title-only" does a fuzzy search
+                      over openapi and page titles "all-content" will fuzzy search
+                      over all openapi and page content. "title-only" is the default.
+                      warning:  using all-content may incur a larger memory footprint'
+                      enum:
+                        - title-only
+                        - all-content
+                      type: string
+                  type: object
+                selector:
+                  description: Selector is used for choosing what is shown in the DevPortal
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: MatchLabels specifies the list of labels that must
+                        be present in Mappings for being present in this DevPortal.
+                      type: object
+                    matchNamespaces:
+                      description: MatchNamespaces is a list of namespaces that will
+                        be included in this DevPortal.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: "DevPortal is the Schema for the DevPortals API \n DevPortal
+          resources specify the `what` and `how` is shown in a DevPortal: \n * `what`
+          is in a DevPortal can be controlled with   - a `selector`, that can be used
+          for filtering `Mappings`.   - a `docs` listing of (services, url) * `how`
+          is a pointer to some `contents` (a checkout of a Git repository   with go-templates/markdown/css).
+          \n Multiple `DevPortal`s can exist in the cluster, and the Dev Portal server
+          will show them at different endpoints. A `DevPortal` resource with a special
+          name, `ambassador`, will be used for configuring the default Dev Portal
+          (served at `/docs/` by default)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DevPortalSpec defines the desired state of DevPortal
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                content:
+                  description: Content specifies where the content shown in the DevPortal
+                    come from
+                  properties:
+                    branch:
+                      type: string
+                    dir:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                default:
+                  description: Default must be true when this is the default DevPortal
+                  type: boolean
+                docs:
+                  description: Docs is a static docs definition
+                  items:
+                    description: 'DevPortalDocsSpec is a static documentation definition:
+                    instead of using a Selector for finding documentation for services,
+                    users can provide a static list of <service>:<URL> tuples. These
+                    services will be shown in the Dev Portal with the documentation
+                    obtained from this URL.'
+                    properties:
+                      service:
+                        description: Service is the service being documented
+                        type: string
+                      timeout_ms:
+                        description: Timeout specifies the amount of time devportal
+                          will wait for the downstream service to report an openapi
+                          spec back
+                        type: integer
+                      url:
+                        description: URL is the URL used for obtaining docs
+                        type: string
+                    type: object
+                  type: array
+                naming_scheme:
+                  description: Describes how to display "services" in the DevPortal.
+                    Default namespace.name
+                  enum:
+                    - namespace.name
+                    - name.prefix
+                  type: string
+                preserve_servers:
+                  description: Configures this DevPortal to use server definitions from
+                    the openAPI doc instead of rewriting them based on the url used
+                    for the connection.
+                  type: boolean
+                search:
+                  description: DevPortalSearchSpec allows configuration over search
+                    functionality for the DevPortal
+                  properties:
+                    enabled:
+                      type: boolean
+                    type:
+                      description: 'Type of search. "title-only" does a fuzzy search
+                      over openapi and page titles "all-content" will fuzzy search
+                      over all openapi and page content. "title-only" is the default.
+                      warning:  using all-content may incur a larger memory footprint'
+                      enum:
+                        - title-only
+                        - all-content
+                      type: string
+                  type: object
+                selector:
+                  description: Selector is used for choosing what is shown in the DevPortal
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: MatchLabels specifies the list of labels that must
+                        be present in Mappings for being present in this DevPortal.
+                      type: object
+                    matchNamespaces:
+                      description: MatchNamespaces is a list of namespaces that will
+                        be included in this DevPortal.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: DevPortal is the Schema for the DevPortals API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: hosts.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: Host
+    listKind: HostList
+    plural: hosts
+    singular: host
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.hostname
+          name: Hostname
+          type: string
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .status.phaseCompleted
+          name: Phase Completed
+          type: string
+        - jsonPath: .status.phasePending
+          name: Phase Pending
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v2
+      schema:
+        openAPIV3Schema:
+          description: Host is the Schema for the hosts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HostSpec defines the desired state of Host
+              properties:
+                acmeProvider:
+                  description: Specifies whether/who to talk ACME with to automatically
+                    manage the $tlsSecret.
+                  properties:
+                    authority:
+                      description: Specifies who to talk ACME with to get certs. Defaults
+                        to Let's Encrypt; if "none" (case-insensitive), do not try to
+                        do ACME for this Host.
+                      type: string
+                    email:
+                      type: string
+                    privateKeySecret:
+                      description: "Specifies the Kubernetes Secret to use to store
+                      the private key of the ACME account (essentially, where to store
+                      the auto-generated password for the auto-created ACME account).
+                      \ You should not normally need to set this--the default value
+                      is based on a combination of the ACME authority being registered
+                      wit and the email address associated with the account. \n Note
+                      that this is a native-Kubernetes-style core.v1.LocalObjectReference,
+                      not an Ambassador-style `{name}.{namespace}` string.  Because
+                      we're opinionated, it does not support referencing a Secret
+                      in another namespace (because most native Kubernetes resources
+                      don't support that), but if we ever abandon that opinion and
+                      decide to support non-local references it, it would be by adding
+                      a `namespace:` field by changing it from a core.v1.LocalObjectReference
+                      to a core.v1.SecretReference, not by adopting the `{name}.{namespace}`
+                      notation."
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    registration:
+                      description: This is normally set automatically
+                      type: string
+                  type: object
+                hostname:
+                  description: Hostname by which the Ambassador can be reached.
+                  type: string
+                previewUrl:
+                  description: Configuration for the Preview URL feature of Service
+                    Preview. Defaults to preview URLs not enabled.
+                  properties:
+                    enabled:
+                      description: Is the Preview URL feature enabled?
+                      type: boolean
+                    type:
+                      description: What type of Preview URL is allowed?
+                      enum:
+                        - Path
+                      type: string
+                  type: object
+                requestPolicy:
+                  description: Request policy definition.
+                  properties:
+                    insecure:
+                      properties:
+                        action:
+                          enum:
+                            - Redirect
+                            - Reject
+                            - Route
+                          type: string
+                        additionalPort:
+                          type: integer
+                      type: object
+                  type: object
+                selector:
+                  description: Selector by which we can find further configuration.
+                    Defaults to hostname=$hostname
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                tls:
+                  description: TLS configuration.  It is not valid to specify both `tlsContext`
+                    and `tls`.
+                  properties:
+                    alpn_protocols:
+                      type: string
+                    ca_secret:
+                      type: string
+                    cacert_chain_file:
+                      type: string
+                    cert_chain_file:
+                      type: string
+                    cert_required:
+                      type: boolean
+                    cipher_suites:
+                      items:
+                        type: string
+                      type: array
+                    ecdh_curves:
+                      items:
+                        type: string
+                      type: array
+                    max_tls_version:
+                      type: string
+                    min_tls_version:
+                      type: string
+                    private_key_file:
+                      type: string
+                    redirect_cleartext_from:
+                      type: integer
+                    sni:
+                      type: string
+                    v3CRLSecret:
+                      type: string
+                  type: object
+                tlsContext:
+                  description: "Name of the TLSContext the Host resource is linked with.
+                  It is not valid to specify both `tlsContext` and `tls`. \n Note
+                  that this is a native-Kubernetes-style core.v1.LocalObjectReference,
+                  not an Ambassador-style `{name}.{namespace}` string.  Because we're
+                  opinionated, it does not support referencing a Secret in another
+                  namespace (because most native Kubernetes resources don't support
+                  that), but if we ever abandon that opinion and decide to support
+                  non-local references it, it would be by adding a `namespace:` field
+                  by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference,
+                  not by adopting the `{name}.{namespace}` notation."
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                tlsSecret:
+                  description: "Name of the Kubernetes secret into which to save generated
+                  certificates.  If ACME is enabled (see $acmeProvider), then the
+                  default is $hostname; otherwise the default is \"\".  If the value
+                  is \"\", then we do not do TLS for this Host. \n Note that this
+                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
+                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
+                  it does not support referencing a Secret in another namespace (because
+                  most native Kubernetes resources don't support that), but if we
+                  ever abandon that opinion and decide to support non-local references
+                  it, it would be by adding a `namespace:` field by changing it from
+                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
+                  by adopting the `{name}.{namespace}` notation."
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: HostStatus defines the observed state of Host
+              properties:
+                errorBackoff:
+                  type: string
+                errorReason:
+                  description: errorReason, errorTimestamp, and errorBackoff are valid
+                    when state==Error.
+                  type: string
+                errorTimestamp:
+                  format: date-time
+                  type: string
+                phaseCompleted:
+                  description: phaseCompleted and phasePending are valid when state==Pending
+                    or state==Error.
+                  enum:
+                    - NA
+                    - DefaultsFilled
+                    - ACMEUserPrivateKeyCreated
+                    - ACMEUserRegistered
+                    - ACMECertificateChallenge
+                  type: string
+                phasePending:
+                  description: phaseCompleted and phasePending are valid when state==Pending
+                    or state==Error.
+                  enum:
+                    - NA
+                    - DefaultsFilled
+                    - ACMEUserPrivateKeyCreated
+                    - ACMEUserRegistered
+                    - ACMECertificateChallenge
+                  type: string
+                state:
+                  description: The first value listed in the Enum marker becomes the
+                    "zero" value, and it would be great if "Pending" could be the default
+                    value; but it's Important that the "zero" value be able to be shown
+                    as empty/omitted from display, and we really do want `kubectl get
+                    hosts` to say "Pending" in the "STATE" column, and not leave the
+                    column empty.
+                  enum:
+                    - Initial
+                    - Pending
+                    - Ready
+                    - Error
+                  type: string
+                tlsCertificateSource:
+                  enum:
+                    - Unknown
+                    - None
+                    - Other
+                    - ACME
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.hostname
+          name: Hostname
+          type: string
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .status.phaseCompleted
+          name: Phase Completed
+          type: string
+        - jsonPath: .status.phasePending
+          name: Phase Pending
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: Host is the Schema for the hosts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HostSpec defines the desired state of Host
+              properties:
+                acmeProvider:
+                  description: Specifies whether/who to talk ACME with to automatically
+                    manage the $tlsSecret.
+                  properties:
+                    authority:
+                      description: Specifies who to talk ACME with to get certs. Defaults
+                        to Let's Encrypt; if "none" (case-insensitive), do not try to
+                        do ACME for this Host.
+                      type: string
+                    email:
+                      type: string
+                    privateKeySecret:
+                      description: "Specifies the Kubernetes Secret to use to store
+                      the private key of the ACME account (essentially, where to store
+                      the auto-generated password for the auto-created ACME account).
+                      \ You should not normally need to set this--the default value
+                      is based on a combination of the ACME authority being registered
+                      wit and the email address associated with the account. \n Note
+                      that this is a native-Kubernetes-style core.v1.LocalObjectReference,
+                      not an Ambassador-style `{name}.{namespace}` string.  Because
+                      we're opinionated, it does not support referencing a Secret
+                      in another namespace (because most native Kubernetes resources
+                      don't support that), but if we ever abandon that opinion and
+                      decide to support non-local references it, it would be by adding
+                      a `namespace:` field by changing it from a core.v1.LocalObjectReference
+                      to a core.v1.SecretReference, not by adopting the `{name}.{namespace}`
+                      notation."
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    registration:
+                      description: This is normally set automatically
+                      type: string
+                  type: object
+                ambassador_id:
+                  description: Common to all Ambassador objects (and optional).
+                  items:
+                    type: string
+                  type: array
+                hostname:
+                  description: Hostname by which the Ambassador can be reached.
+                  type: string
+                mappingSelector:
+                  description: Selector for Mappings we'll associate with this Host.
+                    At the moment, Selector and MappingSelector are synonyms, but that
+                    will change soon.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                previewUrl:
+                  description: Configuration for the Preview URL feature of Service
+                    Preview. Defaults to preview URLs not enabled.
+                  properties:
+                    enabled:
+                      description: Is the Preview URL feature enabled?
+                      type: boolean
+                    type:
+                      description: What type of Preview URL is allowed?
+                      enum:
+                        - Path
+                      type: string
+                  type: object
+                requestPolicy:
+                  description: Request policy definition.
+                  properties:
+                    insecure:
+                      properties:
+                        action:
+                          enum:
+                            - Redirect
+                            - Reject
+                            - Route
+                          type: string
+                        additionalPort:
+                          type: integer
+                      type: object
+                  type: object
+                selector:
+                  description: "DEPRECATED: Selector by which we can find further configuration.
+                  Use MappingSelector instead. \n TODO(lukeshu): In v3alpha2, figure
+                  out how to get rid of HostSpec.DeprecatedSelector."
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                tls:
+                  description: TLS configuration.  It is not valid to specify both `tlsContext`
+                    and `tls`.
+                  properties:
+                    alpn_protocols:
+                      type: string
+                    ca_secret:
+                      type: string
+                    cacert_chain_file:
+                      type: string
+                    cert_chain_file:
+                      type: string
+                    cert_required:
+                      type: boolean
+                    cipher_suites:
+                      items:
+                        type: string
+                      type: array
+                    crl_secret:
+                      type: string
+                    ecdh_curves:
+                      items:
+                        type: string
+                      type: array
+                    max_tls_version:
+                      type: string
+                    min_tls_version:
+                      type: string
+                    private_key_file:
+                      type: string
+                    redirect_cleartext_from:
+                      type: integer
+                    sni:
+                      type: string
+                  type: object
+                tlsContext:
+                  description: "Name of the TLSContext the Host resource is linked with.
+                  It is not valid to specify both `tlsContext` and `tls`. \n Note
+                  that this is a native-Kubernetes-style core.v1.LocalObjectReference,
+                  not an Ambassador-style `{name}.{namespace}` string.  Because we're
+                  opinionated, it does not support referencing a Secret in another
+                  namespace (because most native Kubernetes resources don't support
+                  that), but if we ever abandon that opinion and decide to support
+                  non-local references it, it would be by adding a `namespace:` field
+                  by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference,
+                  not by adopting the `{name}.{namespace}` notation."
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                tlsSecret:
+                  description: "Name of the Kubernetes secret into which to save generated
+                  certificates.  If ACME is enabled (see $acmeProvider), then the
+                  default is $hostname; otherwise the default is \"\".  If the value
+                  is \"\", then we do not do TLS for this Host. \n Note that this
+                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
+                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
+                  it does not support referencing a Secret in another namespace (because
+                  most native Kubernetes resources don't support that), but if we
+                  ever abandon that opinion and decide to support non-local references
+                  it, it would be by adding a `namespace:` field by changing it from
+                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
+                  by adopting the `{name}.{namespace}` notation."
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: HostStatus defines the observed state of Host
+              properties:
+                errorBackoff:
+                  type: string
+                errorReason:
+                  description: errorReason, errorTimestamp, and errorBackoff are valid
+                    when state==Error.
+                  type: string
+                errorTimestamp:
+                  format: date-time
+                  type: string
+                phaseCompleted:
+                  description: phaseCompleted and phasePending are valid when state==Pending
+                    or state==Error.
+                  enum:
+                    - NA
+                    - DefaultsFilled
+                    - ACMEUserPrivateKeyCreated
+                    - ACMEUserRegistered
+                    - ACMECertificateChallenge
+                  type: string
+                phasePending:
+                  description: phaseCompleted and phasePending are valid when state==Pending
+                    or state==Error.
+                  enum:
+                    - NA
+                    - DefaultsFilled
+                    - ACMEUserPrivateKeyCreated
+                    - ACMEUserRegistered
+                    - ACMECertificateChallenge
+                  type: string
+                state:
+                  description: The first value listed in the Enum marker becomes the
+                    "zero" value, and it would be great if "Pending" could be the default
+                    value; but it's Important that the "zero" value be able to be shown
+                    as empty/omitted from display, and we really do want `kubectl get
+                    hosts` to say "Pending" in the "STATE" column, and not leave the
+                    column empty.
+                  enum:
+                    - Initial
+                    - Pending
+                    - Ready
+                    - Error
+                  type: string
+                tlsCertificateSource:
+                  enum:
+                    - Unknown
+                    - None
+                    - Other
+                    - ACME
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: kubernetesendpointresolvers.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: KubernetesEndpointResolver
+    listKind: KubernetesEndpointResolverList
+    plural: kubernetesendpointresolvers
+    singular: kubernetesendpointresolver
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubernetesEndpointResolver tells Ambassador to use Kubernetes
+                Endpoints resources to resolve services. It actually has no spec other
+                than the AmbassadorID.
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubernetesEndpointResolver tells Ambassador to use Kubernetes
+                Endpoints resources to resolve services. It actually has no spec other
+                than the AmbassadorID.
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver
+            API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: kubernetesserviceresolvers.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: KubernetesServiceResolver
+    listKind: KubernetesServiceResolverList
+    plural: kubernetesserviceresolvers
+    singular: kubernetesserviceresolver
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubernetesServiceResolver tells Ambassador to use Kubernetes
+                Service resources to resolve services. It actually has no spec other
+                than the AmbassadorID.
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubernetesServiceResolver tells Ambassador to use Kubernetes
+                Service resources to resolve services. It actually has no spec other
+                than the AmbassadorID.
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver
+            API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: listeners.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: Listener
+    listKind: ListenerList
+    plural: listeners
+    singular: listener
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.port
+          name: Port
+          type: string
+        - jsonPath: .spec.protocol
+          name: Protocol
+          type: string
+        - jsonPath: .spec.protocolStack
+          name: Stack
+          type: string
+        - jsonPath: .spec.statsPrefix
+          name: StatsPrefix
+          type: string
+        - jsonPath: .spec.securityModel
+          name: Security
+          type: string
+        - jsonPath: .spec.l7Depth
+          name: L7Depth
+          type: string
+      name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: Listener is the Schema for the hosts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ListenerSpec defines the desired state of this Port
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                hostBinding:
+                  description: HostBinding allows restricting which Hosts will be used
+                    for this Listener.
+                  properties:
+                    namespace:
+                      description: NamespaceBindingType defines we we specify which
+                        namespaces to look for Hosts in.
+                      properties:
+                        from:
+                          description: NamespaceFromType defines how we evaluate a NamespaceBindingType.
+                          enum:
+                            - SELF
+                            - ALL
+                            - SELECTOR
+                          type: string
+                      type: object
+                    selector:
+                      description: A label selector is a label query over a set of resources.
+                        The result of matchLabels and matchExpressions are ANDed. An
+                        empty label selector matches all objects. A null label selector
+                        matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If
+                                  the operator is In or NotIn, the values array must
+                                  be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced
+                                  during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A
+                            single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is "key",
+                            the operator is "In", and the values array contains only
+                            "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                  type: object
+                l7Depth:
+                  description: L7Depth specifies how many layer 7 load balancers are
+                    between us and the edge of the network.
+                  format: int32
+                  type: integer
+                port:
+                  description: Port is the network port. Only one Listener can use a
+                    given port.
+                  format: int32
+                  maximum: 65535
+                  minimum: 1
+                  type: integer
+                protocol:
+                  description: Protocol is a shorthand for certain predefined stacks.
+                    Exactly one of Protocol or ProtocolStack must be supplied.
+                  enum:
+                    - HTTP
+                    - HTTPS
+                    - HTTPPROXY
+                    - HTTPSPROXY
+                    - TCP
+                    - TLS
+                    - UDP
+                  type: string
+                protocolStack:
+                  description: ProtocolStack explicitly specifies the protocol stack
+                    to set up. Exactly one of Protocol or ProtocolStack must be supplied.
+                  items:
+                    description: ProtocolStackElement defines specific layers that may
+                      be combined in a protocol stack for processing connections to
+                      a port.
+                    enum:
+                      - HTTP
+                      - PROXY
+                      - TLS
+                      - TCP
+                      - UDP
+                    type: string
+                  type: array
+                securityModel:
+                  description: SecurityModel specifies how to determine whether connections
+                    to this port are secure or insecure.
+                  enum:
+                    - XFP
+                    - SECURE
+                    - INSECURE
+                  type: string
+                statsPrefix:
+                  description: 'StatsPrefix specifies the prefix for statistics sent
+                  by Envoy about this Listener. The default depends on the protocol:
+                  "ingress-http", "ingress-https", "ingress-tls-$port", or "ingress-$port".'
+                  type: string
+              required:
+                - hostBinding
+                - port
+                - securityModel
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: logservices.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: LogService
+    listKind: LogServiceList
+    plural: logservices
+    singular: logservice
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: LogService is the Schema for the logservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: LogServiceSpec defines the desired state of LogService
+              properties:
+                driver:
+                  enum:
+                    - tcp
+                    - http
+                  type: string
+                driver_config:
+                  properties:
+                    additional_log_headers:
+                      items:
+                        properties:
+                          during_request:
+                            type: boolean
+                          during_response:
+                            type: boolean
+                          during_trailer:
+                            type: boolean
+                          header_name:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                flush_interval_byte_size:
+                  type: integer
+                flush_interval_time:
+                  type: integer
+                grpc:
+                  type: boolean
+                service:
+                  type: string
+                v3ProtocolVersion:
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                v3StatsName:
+                  type: string
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: LogService is the Schema for the logservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: LogServiceSpec defines the desired state of LogService
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                driver:
+                  enum:
+                    - tcp
+                    - http
+                  type: string
+                driver_config:
+                  properties:
+                    additional_log_headers:
+                      items:
+                        properties:
+                          during_request:
+                            type: boolean
+                          during_response:
+                            type: boolean
+                          during_trailer:
+                            type: boolean
+                          header_name:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                flush_interval_byte_size:
+                  type: integer
+                flush_interval_time:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}s`/`SecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                grpc:
+                  description: 'TODO(lukeshu): In v3alpha2, drop this LogService.spec.grpc.  Due
+                  to sloppy implementation it is required to be present, and required
+                  to be ''true''.  It is silly to have a required field with only
+                  one valid value, we should just remove the thing.'
+                  type: boolean
+                protocol_version:
+                  description: ProtocolVersion is the envoy api transport protocol version
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                service:
+                  type: string
+                stats_name:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: LogService is the Schema for the logservices API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: mappings.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: Mapping
+    listKind: MappingList
+    plural: mappings
+    singular: mapping
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.host
+          name: Source Host
+          type: string
+        - jsonPath: .spec.prefix
+          name: Source Prefix
+          type: string
+        - jsonPath: .spec.service
+          name: Dest Service
+          type: string
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          type: string
+      name: v2
+      schema:
+        openAPIV3Schema:
+          description: Mapping is the Schema for the mappings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MappingSpec defines the desired state of Mapping
+              properties:
+                add_linkerd_headers:
+                  type: boolean
+                add_request_headers:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                add_response_headers:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                allow_upgrade:
+                  description: "A case-insensitive list of the non-HTTP protocols to
+                  allow \"upgrading\" to from HTTP via the \"Connection: upgrade\"
+                  mechanism[1].  After the upgrade, Ambassador does not interpret
+                  the traffic, and behaves similarly to how it does for TCPMappings.
+                  \n [1]: https://tools.ietf.org/html/rfc7230#section-6.7 \n For example,
+                  if your upstream service supports WebSockets, you would write \n
+                  \   allow_upgrade:    - websocket \n Or if your upstream service
+                  supports upgrading from HTTP to SPDY (as the Kubernetes apiserver
+                  does for `kubectl exec` functionality), you would write \n    allow_upgrade:
+                  \   - spdy/3.1"
+                  items:
+                    type: string
+                  type: array
+                auth_context_extensions:
+                  additionalProperties:
+                    type: string
+                  type: object
+                auto_host_rewrite:
+                  type: boolean
+                bypass_auth:
+                  type: boolean
+                bypass_error_response_overrides:
+                  description: If true, bypasses any `error_response_overrides` set
+                    on the Ambassador module.
+                  type: boolean
+                case_sensitive:
+                  type: boolean
+                circuit_breakers:
+                  items:
+                    properties:
+                      max_connections:
+                        type: integer
+                      max_pending_requests:
+                        type: integer
+                      max_requests:
+                        type: integer
+                      max_retries:
+                        type: integer
+                      priority:
+                        enum:
+                          - default
+                          - high
+                        type: string
+                    type: object
+                  type: array
+                cluster_idle_timeout_ms:
+                  type: integer
+                cluster_max_connection_lifetime_ms:
+                  type: integer
+                cluster_tag:
+                  type: string
+                connect_timeout_ms:
+                  type: integer
+                cors:
+                  properties:
+                    credentials:
+                      type: boolean
+                    max_age:
+                      type: string
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dns_type:
+                  type: string
+                docs:
+                  description: DocsInfo provides some extra information about the docs
+                    for the Mapping (used by the Dev Portal)
+                  properties:
+                    display_name:
+                      type: string
+                    ignored:
+                      type: boolean
+                    path:
+                      type: string
+                    timeout_ms:
+                      type: integer
+                    url:
+                      type: string
+                  type: object
+                enable_ipv4:
+                  type: boolean
+                enable_ipv6:
+                  type: boolean
+                envoy_override:
+                  description: UntypedDict is relatively opaque as a Go type, but it
+                    preserves its contents in a roundtrippable way.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                error_response_overrides:
+                  description: Error response overrides for this Mapping. Replaces all
+                    of the `error_response_overrides` set on the Ambassador module,
+                    if any.
+                  items:
+                    description: A response rewrite for an HTTP error response
+                    properties:
+                      body:
+                        description: The new response body
+                        properties:
+                          content_type:
+                            description: The content type to set on the error response
+                              body when using text_format or text_format_source. Defaults
+                              to 'text/plain'.
+                            type: string
+                          json_format:
+                            additionalProperties:
+                              type: string
+                            description: 'A JSON response with content-type: application/json.
+                            The values can contain format text like in text_format.'
+                            type: object
+                          text_format:
+                            description: A format string representing a text response
+                              body. Content-Type can be set using the `content_type`
+                              field below.
+                            type: string
+                          text_format_source:
+                            description: A format string sourced from a file on the
+                              Ambassador container. Useful for larger response bodies
+                              that should not be placed inline in configuration.
+                            properties:
+                              filename:
+                                description: The name of a file on the Ambassador pod
+                                  that contains a format text string.
+                                type: string
+                            type: object
+                        type: object
+                      on_status_code:
+                        description: The status code to match on -- not a pointer because
+                          it's required.
+                        maximum: 599
+                        minimum: 400
+                        type: integer
+                    required:
+                      - body
+                      - on_status_code
+                    type: object
+                  minItems: 1
+                  type: array
+                grpc:
+                  type: boolean
+                headers:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                host:
+                  type: string
+                host_redirect:
+                  type: boolean
+                host_regex:
+                  type: boolean
+                host_rewrite:
+                  type: string
+                idle_timeout_ms:
+                  type: integer
+                keepalive:
+                  properties:
+                    idle_time:
+                      type: integer
+                    interval:
+                      type: integer
+                    probes:
+                      type: integer
+                  type: object
+                labels:
+                  additionalProperties:
+                    description: A MappingLabelGroupsArray is an array of MappingLabelGroups.
+                      I know, complex.
+                    items:
+                      description: 'A MappingLabelGroup is a single element of a MappingLabelGroupsArray:
+                      a second map, where the key is a human-readable name that identifies
+                      the group.'
+                      maxProperties: 1
+                      minProperties: 1
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type: array
+                  description: A DomainMap is the overall Mapping.spec.Labels type.
+                    It maps domains (kind of like namespaces for Mapping labels) to
+                    arrays of label groups.
+                  type: object
+                load_balancer:
+                  properties:
+                    cookie:
+                      properties:
+                        name:
+                          type: string
+                        path:
+                          type: string
+                        ttl:
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    header:
+                      type: string
+                    policy:
+                      enum:
+                        - round_robin
+                        - ring_hash
+                        - maglev
+                        - least_request
+                      type: string
+                    source_ip:
+                      type: boolean
+                  required:
+                    - policy
+                  type: object
+                method:
+                  type: string
+                method_regex:
+                  type: boolean
+                modules:
+                  items:
+                    description: UntypedDict is relatively opaque as a Go type, but
+                      it preserves its contents in a roundtrippable way.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                outlier_detection:
+                  type: string
+                path_redirect:
+                  description: Path replacement to use when generating an HTTP redirect.
+                    Used with `host_redirect`.
+                  type: string
+                precedence:
+                  type: integer
+                prefix:
+                  type: string
+                prefix_exact:
+                  type: boolean
+                prefix_redirect:
+                  description: Prefix rewrite to use when generating an HTTP redirect.
+                    Used with `host_redirect`.
+                  type: string
+                prefix_regex:
+                  type: boolean
+                priority:
+                  type: string
+                query_parameters:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                redirect_response_code:
+                  description: The response code to use when generating an HTTP redirect.
+                    Defaults to 301. Used with `host_redirect`.
+                  enum:
+                    - 301
+                    - 302
+                    - 303
+                    - 307
+                    - 308
+                  type: integer
+                regex_headers:
+                  additionalProperties:
+                    type: string
+                  type: object
+                regex_query_parameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                regex_redirect:
+                  description: Prefix regex rewrite to use when generating an HTTP redirect.
+                    Used with `host_redirect`.
+                  properties:
+                    pattern:
+                      type: string
+                    substitution:
+                      type: string
+                  type: object
+                regex_rewrite:
+                  properties:
+                    pattern:
+                      type: string
+                    substitution:
+                      type: string
+                  type: object
+                resolver:
+                  type: string
+                respect_dns_ttl:
+                  type: boolean
+                retry_policy:
+                  properties:
+                    num_retries:
+                      type: integer
+                    per_try_timeout:
+                      type: string
+                    retry_on:
+                      enum:
+                        - 5xx
+                        - gateway-error
+                        - connect-failure
+                        - retriable-4xx
+                        - refused-stream
+                        - retriable-status-codes
+                      type: string
+                  type: object
+                rewrite:
+                  type: string
+                service:
+                  type: string
+                shadow:
+                  type: boolean
+                timeout_ms:
+                  description: The timeout for requests that use this Mapping. Overrides
+                    `cluster_request_timeout_ms` set on the Ambassador Module, if it
+                    exists.
+                  type: integer
+                use_websocket:
+                  description: 'use_websocket is deprecated, and is equivlaent to setting
+                  `allow_upgrade: ["websocket"]`'
+                  type: boolean
+                v3StatsName:
+                  type: string
+                weight:
+                  type: integer
+              required:
+                - prefix
+                - service
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: MappingStatus defines the observed state of Mapping
+              properties:
+                reason:
+                  type: string
+                state:
+                  enum:
+                    - ""
+                    - Inactive
+                    - Running
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.host
+          name: Source Host
+          type: string
+        - jsonPath: .spec.prefix
+          name: Source Prefix
+          type: string
+        - jsonPath: .spec.service
+          name: Dest Service
+          type: string
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          type: string
+      name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: Mapping is the Schema for the mappings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MappingSpec defines the desired state of Mapping
+              properties:
+                add_linkerd_headers:
+                  type: boolean
+                add_request_headers:
+                  additionalProperties:
+                    properties:
+                      append:
+                        type: boolean
+                      v2Representation:
+                        enum:
+                          - ""
+                          - string
+                          - "null"
+                        type: string
+                      value:
+                        type: string
+                    type: object
+                  type: object
+                add_response_headers:
+                  additionalProperties:
+                    properties:
+                      append:
+                        type: boolean
+                      v2Representation:
+                        enum:
+                          - ""
+                          - string
+                          - "null"
+                        type: string
+                      value:
+                        type: string
+                    type: object
+                  type: object
+                allow_upgrade:
+                  description: "A case-insensitive list of the non-HTTP protocols to
+                  allow \"upgrading\" to from HTTP via the \"Connection: upgrade\"
+                  mechanism[1].  After the upgrade, Ambassador does not interpret
+                  the traffic, and behaves similarly to how it does for TCPMappings.
+                  \n [1]: https://tools.ietf.org/html/rfc7230#section-6.7 \n For example,
+                  if your upstream service supports WebSockets, you would write \n
+                  \   allow_upgrade:    - websocket \n Or if your upstream service
+                  supports upgrading from HTTP to SPDY (as the Kubernetes apiserver
+                  does for `kubectl exec` functionality), you would write \n    allow_upgrade:
+                  \   - spdy/3.1"
+                  items:
+                    type: string
+                  type: array
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                auth_context_extensions:
+                  additionalProperties:
+                    type: string
+                  type: object
+                auto_host_rewrite:
+                  type: boolean
+                bypass_auth:
+                  type: boolean
+                bypass_error_response_overrides:
+                  description: If true, bypasses any `error_response_overrides` set
+                    on the Ambassador module.
+                  type: boolean
+                case_sensitive:
+                  type: boolean
+                circuit_breakers:
+                  items:
+                    properties:
+                      max_connections:
+                        type: integer
+                      max_pending_requests:
+                        type: integer
+                      max_requests:
+                        type: integer
+                      max_retries:
+                        type: integer
+                      priority:
+                        enum:
+                          - default
+                          - high
+                        type: string
+                    type: object
+                  type: array
+                cluster_idle_timeout_ms:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                cluster_max_connection_lifetime_ms:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                cluster_tag:
+                  type: string
+                connect_timeout_ms:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                cors:
+                  properties:
+                    credentials:
+                      type: boolean
+                    exposed_headers:
+                      items:
+                        type: string
+                      type: array
+                    headers:
+                      items:
+                        type: string
+                      type: array
+                    max_age:
+                      type: string
+                    methods:
+                      items:
+                        type: string
+                      type: array
+                    origins:
+                      items:
+                        type: string
+                      type: array
+                    v2CommaSeparatedOrigins:
+                      type: boolean
+                  type: object
+                dns_type:
+                  type: string
+                docs:
+                  description: DocsInfo provides some extra information about the docs
+                    for the Mapping. Docs is used by both the agent and the DevPortal.
+                  properties:
+                    display_name:
+                      type: string
+                    ignored:
+                      type: boolean
+                    path:
+                      type: string
+                    timeout_ms:
+                      description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                      fields to `{foo}`/`metav1.Duration`.'
+                      type: integer
+                    url:
+                      type: string
+                  type: object
+                enable_ipv4:
+                  type: boolean
+                enable_ipv6:
+                  type: boolean
+                envoy_override:
+                  description: UntypedDict is relatively opaque as a Go type, but it
+                    preserves its contents in a roundtrippable way.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                error_response_overrides:
+                  description: Error response overrides for this Mapping. Replaces all
+                    of the `error_response_overrides` set on the Ambassador module,
+                    if any.
+                  items:
+                    description: A response rewrite for an HTTP error response
+                    properties:
+                      body:
+                        description: The new response body
+                        properties:
+                          content_type:
+                            description: The content type to set on the error response
+                              body when using text_format or text_format_source. Defaults
+                              to 'text/plain'.
+                            type: string
+                          json_format:
+                            additionalProperties:
+                              type: string
+                            description: 'A JSON response with content-type: application/json.
+                            The values can contain format text like in text_format.'
+                            type: object
+                          text_format:
+                            description: A format string representing a text response
+                              body. Content-Type can be set using the `content_type`
+                              field below.
+                            type: string
+                          text_format_source:
+                            description: A format string sourced from a file on the
+                              Ambassador container. Useful for larger response bodies
+                              that should not be placed inline in configuration.
+                            properties:
+                              filename:
+                                description: The name of a file on the Ambassador pod
+                                  that contains a format text string.
+                                type: string
+                            type: object
+                        type: object
+                      on_status_code:
+                        description: The status code to match on -- not a pointer because
+                          it's required.
+                        maximum: 599
+                        minimum: 400
+                        type: integer
+                    required:
+                      - body
+                      - on_status_code
+                    type: object
+                  minItems: 1
+                  type: array
+                grpc:
+                  type: boolean
+                headers:
+                  additionalProperties:
+                    type: string
+                  type: object
+                host:
+                  description: "Exact match for the hostname of a request if HostRegex
+                  is false; regex match for the hostname if HostRegex is true. \n
+                  Host specifies both a match for the ':authority' header of a request,
+                  as well as a match criterion for Host CRDs: a Mapping that specifies
+                  Host will not associate with a Host that doesn't have a matching
+                  Hostname. \n If both Host and Hostname are set, an error is logged,
+                  Host is ignored, and Hostname is used. \n DEPRECATED: Host is either
+                  an exact match or a regex, depending on HostRegex. Use HostName
+                  instead. \n TODO(lukeshu): In v3alpha2, get rid of MappingSpec.host
+                  and MappingSpec.host_regex in favor of a MappingSpec.deprecated_hostname_regex."
+                  type: string
+                host_redirect:
+                  type: boolean
+                host_regex:
+                  description: "DEPRECATED: Host is either an exact match or a regex,
+                  depending on HostRegex. Use HostName instead. \n TODO(lukeshu):
+                  In v3alpha2, get rid of MappingSpec.host and MappingSpec.host_regex
+                  in favor of a MappingSpec.deprecated_hostname_regex."
+                  type: boolean
+                host_rewrite:
+                  type: string
+                hostname:
+                  description: "Hostname is a DNS glob specifying the hosts to which
+                  this Mapping applies. \n Hostname specifies both a match for the
+                  ':authority' header of a request, as well as a match criterion for
+                  Host CRDs: a Mapping that specifies Hostname will not associate
+                  with a Host that doesn't have a matching Hostname. \n If both Host
+                  and Hostname are set, an error is logged, Host is ignored, and Hostname
+                  is used."
+                  type: string
+                idle_timeout_ms:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                keepalive:
+                  properties:
+                    idle_time:
+                      type: integer
+                    interval:
+                      type: integer
+                    probes:
+                      type: integer
+                  type: object
+                labels:
+                  additionalProperties:
+                    description: A MappingLabelGroupsArray is an array of MappingLabelGroups.
+                      I know, complex.
+                    items:
+                      additionalProperties:
+                        description: 'A MappingLabelsArray is the value in the MappingLabelGroup:
+                        an array of label specifiers.'
+                        items:
+                          description: "A MappingLabelSpecifier (finally!) defines a
+                          single label. \n This mimics envoy/config/route/v3/route_components.proto:RateLimit:Action:action_specifier."
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            destination_cluster:
+                              description: Sets the label "destination_cluster=«Envoy
+                                destination cluster name»".
+                              properties:
+                                key:
+                                  enum:
+                                    - destination_cluster
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            generic_key:
+                              description: Sets the label "«key»=«value»" (where by
+                                default «key» is "generic_key").
+                              properties:
+                                key:
+                                  description: The default is "generic_key".
+                                  type: string
+                                v2Shorthand:
+                                  type: boolean
+                                value:
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                            remote_address:
+                              description: Sets the label "remote_address=«IP address
+                                of the client»".
+                              properties:
+                                key:
+                                  enum:
+                                    - remote_address
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            request_headers:
+                              description: If the «header_name» header is set, then
+                                set the label "«key»=«Value of the «header_name» header»";
+                                otherwise skip applying this label group.
+                              properties:
+                                header_name:
+                                  type: string
+                                key:
+                                  type: string
+                                omit_if_not_present:
+                                  type: boolean
+                              required:
+                                - header_name
+                                - key
+                              type: object
+                            source_cluster:
+                              description: Sets the label "source_cluster=«Envoy source
+                                cluster name»".
+                              properties:
+                                key:
+                                  enum:
+                                    - source_cluster
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                          type: object
+                        type: array
+                      description: 'A MappingLabelGroup is a single element of a MappingLabelGroupsArray:
+                      a second map, where the key is a human-readable name that identifies
+                      the group.'
+                      maxProperties: 1
+                      minProperties: 1
+                      type: object
+                    type: array
+                  description: A DomainMap is the overall Mapping.spec.Labels type.
+                    It maps domains (kind of like namespaces for Mapping labels) to
+                    arrays of label groups.
+                  type: object
+                load_balancer:
+                  properties:
+                    cookie:
+                      properties:
+                        name:
+                          type: string
+                        path:
+                          type: string
+                        ttl:
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    header:
+                      type: string
+                    policy:
+                      enum:
+                        - round_robin
+                        - ring_hash
+                        - maglev
+                        - least_request
+                      type: string
+                    source_ip:
+                      type: boolean
+                  required:
+                    - policy
+                  type: object
+                method:
+                  type: string
+                method_regex:
+                  type: boolean
+                modules:
+                  items:
+                    description: UntypedDict is relatively opaque as a Go type, but
+                      it preserves its contents in a roundtrippable way.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                outlier_detection:
+                  type: string
+                path_redirect:
+                  description: Path replacement to use when generating an HTTP redirect.
+                    Used with `host_redirect`.
+                  type: string
+                precedence:
+                  type: integer
+                prefix:
+                  type: string
+                prefix_exact:
+                  type: boolean
+                prefix_redirect:
+                  description: Prefix rewrite to use when generating an HTTP redirect.
+                    Used with `host_redirect`.
+                  type: string
+                prefix_regex:
+                  type: boolean
+                priority:
+                  type: string
+                query_parameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                redirect_response_code:
+                  description: The response code to use when generating an HTTP redirect.
+                    Defaults to 301. Used with `host_redirect`.
+                  enum:
+                    - 301
+                    - 302
+                    - 303
+                    - 307
+                    - 308
+                  type: integer
+                regex_headers:
+                  additionalProperties:
+                    type: string
+                  type: object
+                regex_query_parameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                regex_redirect:
+                  description: Prefix regex rewrite to use when generating an HTTP redirect.
+                    Used with `host_redirect`.
+                  properties:
+                    pattern:
+                      type: string
+                    substitution:
+                      type: string
+                  type: object
+                regex_rewrite:
+                  properties:
+                    pattern:
+                      type: string
+                    substitution:
+                      type: string
+                  type: object
+                remove_request_headers:
+                  items:
+                    type: string
+                  type: array
+                remove_response_headers:
+                  items:
+                    type: string
+                  type: array
+                resolver:
+                  type: string
+                respect_dns_ttl:
+                  type: boolean
+                retry_policy:
+                  properties:
+                    num_retries:
+                      type: integer
+                    per_try_timeout:
+                      type: string
+                    retry_on:
+                      enum:
+                        - 5xx
+                        - gateway-error
+                        - connect-failure
+                        - retriable-4xx
+                        - refused-stream
+                        - retriable-status-codes
+                      type: string
+                  type: object
+                rewrite:
+                  type: string
+                service:
+                  type: string
+                shadow:
+                  type: boolean
+                stats_name:
+                  type: string
+                timeout_ms:
+                  description: The timeout for requests that use this Mapping. Overrides
+                    `cluster_request_timeout_ms` set on the Ambassador Module, if it
+                    exists.
+                  type: integer
+                tls:
+                  type: string
+                use_websocket:
+                  description: "use_websocket is deprecated, and is equivlaent to setting
+                  `allow_upgrade: [\"websocket\"]` \n TODO(lukeshu): In v3alpha2,
+                  get rid of MappingSpec.DeprecatedUseWebsocket."
+                  type: boolean
+                v2BoolHeaders:
+                  items:
+                    type: string
+                  type: array
+                v2BoolQueryParameters:
+                  items:
+                    type: string
+                  type: array
+                v2ExplicitTLS:
+                  description: V2ExplicitTLS controls some vanity/stylistic elements
+                    when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS
+                    should not in any way affect the runtime operation of Emissary;
+                    except that it may affect internal names in the Envoy config, which
+                    may in turn affect stats names.  But it should not affect any end-user
+                    observable behavior.
+                  properties:
+                    serviceScheme:
+                      description: "ServiceScheme specifies how to spell and capitalize
+                      the scheme-part of the service URL. \n Acceptable values are
+                      \"http://\" (case-insensitive), \"https://\" (case-insensitive),
+                      or \"\".  The value is used if it agrees with whether or not
+                      this resource enables TLS origination, or if something else
+                      in the resource overrides the scheme."
+                      pattern: ^([hH][tT][tT][pP][sS]?://)?$
+                      type: string
+                    tls:
+                      description: "TLS controls whether and how to represent the \"tls\"
+                      field when its value could be implied by the \"service\" field.
+                      \ In v2, there were a lot of different ways to spell an \"empty\"
+                      value, and this field specifies which way to spell it (and will
+                      therefore only be used if the value will indeed be empty). \n
+                      \ | Value        | Representation                        | Meaning
+                      of representation          |  |--------------+---------------------------------------+------------------------------------|
+                      \ | \"\"           | omit the field                        |
+                      defer to service (no TLSContext)   |  | \"null\"       | store
+                      an explicit \"null\" in the field | defer to service (no TLSContext)
+                      \  |  | \"string\"     | store an empty string in the field
+                      \   | defer to service (no TLSContext)   |  | \"bool:false\"
+                      | store a Boolean \"false\" in the field  | defer to service
+                      (no TLSContext)   |  | \"bool:true\"  | store a Boolean \"true\"
+                      in the field   | originate TLS (no TLSContext)      | \n If
+                      the meaning of the representation contradicts anything else
+                      (if a TLSContext is to be used, or in the case of \"bool:true\"
+                      if TLS is not to be originated), then this field is ignored."
+                      enum:
+                        - ""
+                        - "null"
+                        - bool:true
+                        - bool:false
+                        - string
+                      type: string
+                  type: object
+                weight:
+                  type: integer
+              required:
+                - prefix
+                - service
+              type: object
+            status:
+              description: MappingStatus defines the observed state of Mapping
+              properties:
+                reason:
+                  type: string
+                state:
+                  enum:
+                    - ""
+                    - Inactive
+                    - Running
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Mapping is the Schema for the mappings API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: modules.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: Module
+    listKind: ModuleList
+    plural: modules
+    singular: module
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: "A Module defines system-wide configuration.  The type of module
+          is controlled by the .metadata.name; valid names are \"ambassador\" or \"tls\".
+          \n https://www.getambassador.io/docs/edge-stack/latest/topics/running/ambassador/#the-ambassador-module
+          https://www.getambassador.io/docs/edge-stack/latest/topics/running/tls/#tls-module-deprecated"
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                config:
+                  description: UntypedDict is relatively opaque as a Go type, but it
+                    preserves its contents in a roundtrippable way.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: "A Module defines system-wide configuration.  The type of module
+          is controlled by the .metadata.name; valid names are \"ambassador\" or \"tls\".
+          \n https://www.getambassador.io/docs/edge-stack/latest/topics/running/ambassador/#the-ambassador-module
+          https://www.getambassador.io/docs/edge-stack/latest/topics/running/tls/#tls-module-deprecated"
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'TODO(lukeshu): In v3alpha2, get rid of unnecessary nesting
+              and move `ModuleSpec.config.*` to `ModuleSpec.*`.'
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                config:
+                  description: "TODO(lukeshu): In v3alpha2, change the default from
+                  `diagnostics.enabled=true` to `diagnostics.enabled=false`.  This
+                  needs conversion support in apiext.  See the related comment in
+                  irambassador.py. \n TODO(lukeshu): Structurally type ModuleSpec.Config."
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - config
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: A Module defines system-wide configuration.  The type of module
+            is controlled by the .metadata.name; valid names are "ambassador" or "tls".
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: ratelimitservices.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: RateLimitService
+    listKind: RateLimitServiceList
+    plural: ratelimitservices
+    singular: ratelimitservice
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: RateLimitService is the Schema for the ratelimitservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RateLimitServiceSpec defines the desired state of RateLimitService
+              properties:
+                domain:
+                  type: string
+                protocol_version:
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                service:
+                  type: string
+                timeout_ms:
+                  type: integer
+                v3StatsName:
+                  type: string
+              required:
+                - service
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: RateLimitService is the Schema for the ratelimitservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RateLimitServiceSpec defines the desired state of RateLimitService
+              properties:
+                ambassador_id:
+                  description: Common to all Ambassador objects.
+                  items:
+                    type: string
+                  type: array
+                domain:
+                  type: string
+                protocol_version:
+                  description: ProtocolVersion is the envoy api transport protocol version
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                service:
+                  type: string
+                stats_name:
+                  type: string
+                timeout_ms:
+                  description: 'TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration`
+                  fields to `{foo}`/`metav1.Duration`.'
+                  type: integer
+                tls:
+                  type: string
+                v2ExplicitTLS:
+                  description: V2ExplicitTLS controls some vanity/stylistic elements
+                    when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS
+                    should not in any way affect the runtime operation of Emissary;
+                    except that it may affect internal names in the Envoy config, which
+                    may in turn affect stats names.  But it should not affect any end-user
+                    observable behavior.
+                  properties:
+                    serviceScheme:
+                      description: "ServiceScheme specifies how to spell and capitalize
+                      the scheme-part of the service URL. \n Acceptable values are
+                      \"http://\" (case-insensitive), \"https://\" (case-insensitive),
+                      or \"\".  The value is used if it agrees with whether or not
+                      this resource enables TLS origination, or if something else
+                      in the resource overrides the scheme."
+                      pattern: ^([hH][tT][tT][pP][sS]?://)?$
+                      type: string
+                    tls:
+                      description: "TLS controls whether and how to represent the \"tls\"
+                      field when its value could be implied by the \"service\" field.
+                      \ In v2, there were a lot of different ways to spell an \"empty\"
+                      value, and this field specifies which way to spell it (and will
+                      therefore only be used if the value will indeed be empty). \n
+                      \ | Value        | Representation                        | Meaning
+                      of representation          |  |--------------+---------------------------------------+------------------------------------|
+                      \ | \"\"           | omit the field                        |
+                      defer to service (no TLSContext)   |  | \"null\"       | store
+                      an explicit \"null\" in the field | defer to service (no TLSContext)
+                      \  |  | \"string\"     | store an empty string in the field
+                      \   | defer to service (no TLSContext)   |  | \"bool:false\"
+                      | store a Boolean \"false\" in the field  | defer to service
+                      (no TLSContext)   |  | \"bool:true\"  | store a Boolean \"true\"
+                      in the field   | originate TLS (no TLSContext)      | \n If
+                      the meaning of the representation contradicts anything else
+                      (if a TLSContext is to be used, or in the case of \"bool:true\"
+                      if TLS is not to be originated), then this field is ignored."
+                      enum:
+                        - ""
+                        - "null"
+                        - bool:true
+                        - bool:false
+                        - string
+                      type: string
+                  type: object
+              required:
+                - service
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: RateLimitService is the Schema for the ratelimitservices API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: tcpmappings.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: TCPMapping
+    listKind: TCPMappingList
+    plural: tcpmappings
+    singular: tcpmapping
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: TCPMapping is the Schema for the tcpmappings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TCPMappingSpec defines the desired state of TCPMapping
+              properties:
+                address:
+                  type: string
+                circuit_breakers:
+                  items:
+                    properties:
+                      max_connections:
+                        type: integer
+                      max_pending_requests:
+                        type: integer
+                      max_requests:
+                        type: integer
+                      max_retries:
+                        type: integer
+                      priority:
+                        enum:
+                          - default
+                          - high
+                        type: string
+                    type: object
+                  type: array
+                cluster_tag:
+                  type: string
+                enable_ipv4:
+                  type: boolean
+                enable_ipv6:
+                  type: boolean
+                host:
+                  type: string
+                idle_timeout_ms:
+                  description: 'FIXME(lukeshu): Surely this should be an ''int''?'
+                  type: string
+                port:
+                  description: Port isn't a pointer because it's required.
+                  type: integer
+                resolver:
+                  type: string
+                service:
+                  type: string
+                v3StatsName:
+                  type: string
+                weight:
+                  type: integer
+              required:
+                - port
+                - service
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: TCPMapping is the Schema for the tcpmappings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TCPMappingSpec defines the desired state of TCPMapping
+              properties:
+                address:
+                  type: string
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                circuit_breakers:
+                  items:
+                    properties:
+                      max_connections:
+                        type: integer
+                      max_pending_requests:
+                        type: integer
+                      max_requests:
+                        type: integer
+                      max_retries:
+                        type: integer
+                      priority:
+                        enum:
+                          - default
+                          - high
+                        type: string
+                    type: object
+                  type: array
+                cluster_tag:
+                  type: string
+                enable_ipv4:
+                  type: boolean
+                enable_ipv6:
+                  type: boolean
+                host:
+                  type: string
+                idle_timeout_ms:
+                  description: 'FIXME(lukeshu): Surely this should be an ''int''?'
+                  type: string
+                port:
+                  description: Port isn't a pointer because it's required.
+                  type: integer
+                resolver:
+                  type: string
+                service:
+                  type: string
+                stats_name:
+                  type: string
+                tls:
+                  type: string
+                v2ExplicitTLS:
+                  description: V2ExplicitTLS controls some vanity/stylistic elements
+                    when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS
+                    should not in any way affect the runtime operation of Emissary;
+                    except that it may affect internal names in the Envoy config, which
+                    may in turn affect stats names.  But it should not affect any end-user
+                    observable behavior.
+                  properties:
+                    serviceScheme:
+                      description: "ServiceScheme specifies how to spell and capitalize
+                      the scheme-part of the service URL. \n Acceptable values are
+                      \"http://\" (case-insensitive), \"https://\" (case-insensitive),
+                      or \"\".  The value is used if it agrees with whether or not
+                      this resource enables TLS origination, or if something else
+                      in the resource overrides the scheme."
+                      pattern: ^([hH][tT][tT][pP][sS]?://)?$
+                      type: string
+                    tls:
+                      description: "TLS controls whether and how to represent the \"tls\"
+                      field when its value could be implied by the \"service\" field.
+                      \ In v2, there were a lot of different ways to spell an \"empty\"
+                      value, and this field specifies which way to spell it (and will
+                      therefore only be used if the value will indeed be empty). \n
+                      \ | Value        | Representation                        | Meaning
+                      of representation          |  |--------------+---------------------------------------+------------------------------------|
+                      \ | \"\"           | omit the field                        |
+                      defer to service (no TLSContext)   |  | \"null\"       | store
+                      an explicit \"null\" in the field | defer to service (no TLSContext)
+                      \  |  | \"string\"     | store an empty string in the field
+                      \   | defer to service (no TLSContext)   |  | \"bool:false\"
+                      | store a Boolean \"false\" in the field  | defer to service
+                      (no TLSContext)   |  | \"bool:true\"  | store a Boolean \"true\"
+                      in the field   | originate TLS (no TLSContext)      | \n If
+                      the meaning of the representation contradicts anything else
+                      (if a TLSContext is to be used, or in the case of \"bool:true\"
+                      if TLS is not to be originated), then this field is ignored."
+                      enum:
+                        - ""
+                        - "null"
+                        - bool:true
+                        - bool:false
+                        - string
+                      type: string
+                  type: object
+                weight:
+                  type: integer
+              required:
+                - port
+                - service
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: TCPMapping is the Schema for the tcpmappings API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: tlscontexts.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: TLSContext
+    listKind: TLSContextList
+    plural: tlscontexts
+    singular: tlscontext
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: TLSContext is the Schema for the tlscontexts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TLSContextSpec defines the desired state of TLSContext
+              properties:
+                alpn_protocols:
+                  type: string
+                ca_secret:
+                  type: string
+                cacert_chain_file:
+                  type: string
+                cert_chain_file:
+                  type: string
+                cert_required:
+                  type: boolean
+                cipher_suites:
+                  items:
+                    type: string
+                  type: array
+                ecdh_curves:
+                  items:
+                    type: string
+                  type: array
+                hosts:
+                  items:
+                    type: string
+                  type: array
+                max_tls_version:
+                  enum:
+                    - v1.0
+                    - v1.1
+                    - v1.2
+                    - v1.3
+                  type: string
+                min_tls_version:
+                  enum:
+                    - v1.0
+                    - v1.1
+                    - v1.2
+                    - v1.3
+                  type: string
+                private_key_file:
+                  type: string
+                redirect_cleartext_from:
+                  type: integer
+                secret:
+                  type: string
+                secret_namespacing:
+                  type: boolean
+                sni:
+                  type: string
+                v3CRLSecret:
+                  type: string
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: TLSContext is the Schema for the tlscontexts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TLSContextSpec defines the desired state of TLSContext
+              properties:
+                alpn_protocols:
+                  type: string
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                ca_secret:
+                  type: string
+                cacert_chain_file:
+                  type: string
+                cert_chain_file:
+                  type: string
+                cert_required:
+                  type: boolean
+                cipher_suites:
+                  items:
+                    type: string
+                  type: array
+                crl_secret:
+                  type: string
+                ecdh_curves:
+                  items:
+                    type: string
+                  type: array
+                hosts:
+                  items:
+                    type: string
+                  type: array
+                max_tls_version:
+                  enum:
+                    - v1.0
+                    - v1.1
+                    - v1.2
+                    - v1.3
+                  type: string
+                min_tls_version:
+                  enum:
+                    - v1.0
+                    - v1.1
+                    - v1.2
+                    - v1.3
+                  type: string
+                private_key_file:
+                  type: string
+                redirect_cleartext_from:
+                  type: integer
+                secret:
+                  type: string
+                secret_namespacing:
+                  type: boolean
+                sni:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: TLSContext is the Schema for the tlscontexts API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+  name: tracingservices.getambassador.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: emissary-apiext
+          namespace: emissary-system
+      conversionReviewVersions:
+        - v1beta1
+  group: getambassador.io
+  names:
+    categories:
+      - ambassador-crds
+    kind: TracingService
+    listKind: TracingServiceList
+    plural: tracingservices
+    singular: tracingservice
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: TracingService is the Schema for the tracingservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TracingServiceSpec defines the desired state of TracingService
+              properties:
+                config:
+                  properties:
+                    access_token_file:
+                      type: string
+                    collector_cluster:
+                      type: string
+                    collector_endpoint:
+                      type: string
+                    collector_endpoint_version:
+                      enum:
+                        - HTTP_JSON_V1
+                        - HTTP_JSON
+                        - HTTP_PROTO
+                      type: string
+                    collector_hostname:
+                      type: string
+                    service_name:
+                      type: string
+                    shared_span_context:
+                      type: boolean
+                    trace_id_128bit:
+                      type: boolean
+                    v3PropagationModes:
+                      items:
+                        enum:
+                          - ENVOY
+                          - LIGHTSTEP
+                          - B3
+                          - TRACE_CONTEXT
+                        type: string
+                      type: array
+                  type: object
+                driver:
+                  enum:
+                    - lightstep
+                    - zipkin
+                    - datadog
+                  type: string
+                sampling:
+                  properties:
+                    client:
+                      type: integer
+                    overall:
+                      type: integer
+                    random:
+                      type: integer
+                  type: object
+                service:
+                  type: string
+                tag_headers:
+                  items:
+                    type: string
+                  type: array
+                v3StatsName:
+                  type: string
+              required:
+                - driver
+                - service
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+    - name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: TracingService is the Schema for the tracingservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TracingServiceSpec defines the desired state of TracingService
+              properties:
+                ambassador_id:
+                  description: "AmbassadorID declares which Ambassador instances should
+                  pay attention to this resource. If no value is provided, the default
+                  is: \n    ambassador_id:    - \"default\" \n TODO(lukeshu): In v3alpha2,
+                  consider renaming all of the `ambassador_id` (singular) fields to
+                  `ambassador_ids` (plural)."
+                  items:
+                    type: string
+                  type: array
+                config:
+                  properties:
+                    access_token_file:
+                      type: string
+                    collector_cluster:
+                      type: string
+                    collector_endpoint:
+                      type: string
+                    collector_endpoint_version:
+                      enum:
+                        - HTTP_JSON_V1
+                        - HTTP_JSON
+                        - HTTP_PROTO
+                      type: string
+                    collector_hostname:
+                      type: string
+                    propagation_modes:
+                      items:
+                        enum:
+                          - ENVOY
+                          - LIGHTSTEP
+                          - B3
+                          - TRACE_CONTEXT
+                        type: string
+                      type: array
+                    service_name:
+                      type: string
+                    shared_span_context:
+                      type: boolean
+                    trace_id_128bit:
+                      type: boolean
+                  type: object
+                driver:
+                  enum:
+                    - lightstep
+                    - zipkin
+                    - datadog
+                  type: string
+                sampling:
+                  properties:
+                    client:
+                      type: integer
+                    overall:
+                      type: integer
+                    random:
+                      type: integer
+                  type: object
+                service:
+                  type: string
+                stats_name:
+                  type: string
+                tag_headers:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - driver
+                - service
+              type: object
+          type: object
+      served: true
+      storage: false
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: TracingService is the Schema for the tracingservices API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+---
+################################################################################
+# Namespace                                                                    #
+################################################################################
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: emissary-system
+---
+################################################################################
+# ServiceAccount                                                               #
+################################################################################
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: emissary-apiext
+  namespace: emissary-system
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+---
+################################################################################
+# Cluster permissions                                                          #
+################################################################################
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: emissary-apiext
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+rules:
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "list", "watch" ]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    resourceNames:
+      - authservices.getambassador.io
+      - consulresolvers.getambassador.io
+      - devportals.getambassador.io
+      - filterpolicies.getambassador.io
+      - filters.getambassador.io
+      - hosts.getambassador.io
+      - kubernetesendpointresolvers.getambassador.io
+      - kubernetesserviceresolvers.getambassador.io
+      - listeners.getambassador.io
+      - logservices.getambassador.io
+      - mappings.getambassador.io
+      - modules.getambassador.io
+      - ratelimits.getambassador.io
+      - ratelimitservices.getambassador.io
+      - tcpmappings.getambassador.io
+      - tlscontexts.getambassador.io
+      - tracingservices.getambassador.io
+    verbs: [ "update" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: emissary-apiext
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: emissary-apiext
+subjects:
+  - kind: ServiceAccount
+    namespace: emissary-system
+    name: emissary-apiext
+---
+################################################################################
+# Namespaced permissions                                                       #
+################################################################################
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: emissary-apiext
+  namespace: emissary-system
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["emissary-ingress-webhook-ca"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: emissary-apiext
+  namespace: emissary-system
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: emissary-apiext
+subjects:
+  - kind: ServiceAccount
+    namespace: emissary-system
+    name: emissary-apiext
+---
+################################################################################
+# Main                                                                         #
+################################################################################
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emissary-apiext
+  namespace: emissary-system
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+spec:
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 443
+      targetPort: https
+  selector:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emissary-apiext
+  namespace: emissary-system
+  labels:
+    app.kubernetes.io/instance: emissary-apiext
+    app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+    app.kubernetes.io/name: emissary-apiext
+    app.kubernetes.io/part-of: emissary-apiext
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: emissary-apiext
+      app.kubernetes.io/name: emissary-apiext
+      app.kubernetes.io/part-of: emissary-apiext
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: emissary-apiext
+        app.kubernetes.io/managed-by: kubectl_apply_-f_aes-apiext.yaml
+        app.kubernetes.io/name: emissary-apiext
+        app.kubernetes.io/part-of: emissary-apiext
+    spec:
+      serviceAccountName: emissary-apiext
+      containers:
+        - name: emissary-apiext
+          image: docker.io/datawire/aes:3.1.0
+          imagePullPolicy: IfNotPresent
+          command: [ "apiext", "emissary-apiext" ]
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: https
+              containerPort: 8443
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /probes/live
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 3
+{{- end }}

--- a/charts/bluescape-emissary-crds/values.yaml
+++ b/charts/bluescape-emissary-crds/values.yaml
@@ -1,3 +1,6 @@
 # Default values for bluescape-emissary-crds.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# NOTE: Set to 2 for 2.x CRDs and 3 for 3.x CRDs
+version: "2"


### PR DESCRIPTION
For now, it will default to version 2 CRDs.
Use the "version" field to switch between 2.x and 3.x (see comment in values.yaml)