### PR TITLE
NEX-1282 - updating bluescape-eks-aux to v0.11.0

### DIFF
--- a/charts/bluescape-eks-aux/CHANGELOG.md
+++ b/charts/bluescape-eks-aux/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2017-06-20 - NEX-2048
+## [0.11.0] - 2022-08-01- NEX-1282
+### Changed
+- changing Extra ClusterIssuer to use Secret references for 'accessKeyID'
+
+## [0.10.0] - 2022-06-20 - NEX-2048
 ### Changed
 - cert-manager cluster issuers api version is now dynamic that supports the old and new api versions
 

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-extra.yaml
+++ b/charts/bluescape-eks-aux/templates/cluster-issuer-letsencrypt-extra.yaml
@@ -28,7 +28,9 @@ spec:
           region: {{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.region }}
           role: {{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.role }}
           hostedZoneID: {{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.hosted_zone_id }}
-          accessKeyID: {{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.access_key_id }}
+          accessKeyIDSecretRef:
+            name:   "{{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.name }}"
+            key: accessKeyId
           secretAccessKeySecretRef:
             name:   "{{ .Values.cert_manager.setup_letsencrypt_extra_cluster_issuer.name }}"
             key: secretAccessKey


### PR DESCRIPTION
- changing Extra ClusterIssuer to use Secret references for `accessKeyID`

Tested manually on `a-infra1`