### PR TITLE
Nex-2166 - Resource metrics missing in LENS for andromeda/doe cluster

### DIFF
--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.17.0-alpha1"
+appVersion: "1.16.0"

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2-alpha
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2-alpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.1-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-alpha1
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
+++ b/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
@@ -5,6 +5,8 @@ kind: ConfigMap
 metadata:
   name: prometheus-metrics-proxy-cm
   namespace: monitoring
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
 data:
   haproxy.cfg: |+
     global
@@ -20,7 +22,7 @@ data:
       option  tcplog
       option  dontlognull
             timeout connect 5000
-            timeout client  50000 
+            timeout client  50000
             timeout server  50000
 
     frontend _haproxy_frontend
@@ -45,6 +47,8 @@ kind: DaemonSet
 metadata:
   name: prometheus-metrics-proxy
   namespace: monitoring
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -103,6 +107,8 @@ kind: Service
 metadata:
   name: prometheus-metrics-proxy-service
   namespace: monitoring
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
+++ b/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
@@ -5,6 +5,8 @@ kind: ConfigMap
 metadata:
   name: prometheus-metrics-proxy-cm
   namespace: monitoring
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
 data:
   haproxy.cfg: |+
     global
@@ -45,6 +47,8 @@ kind: DaemonSet
 metadata:
   name: prometheus-metrics-proxy
   namespace: monitoring
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -103,6 +107,8 @@ kind: Service
 metadata:
   name: prometheus-metrics-proxy-service
   namespace: monitoring
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
+++ b/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
@@ -20,7 +20,7 @@ data:
       option  tcplog
       option  dontlognull
             timeout connect 5000
-            timeout client  50000do 
+            timeout client  50000 
             timeout server  50000
 
     frontend _haproxy_frontend

--- a/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
+++ b/charts/istio-additions/templates/prometheus-metrics-proxy-service.yaml
@@ -96,7 +96,8 @@ spec:
         name: haproxy-vol
 ---
 # Service resource pointing to the haproxy. 
-# Add "monitoring/prometheus-metrics-proxy-service:9090" reference of this service goes into the Lens configuration.
+# In Lens select Cluster > Settings > Metrics > Prometheus > Prometheus Operator. 
+# Then set Prometheus > Service Address to "monitoring/prometheus-metrics-proxy-service:9090"
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
This is a bugfix for the previous RP https://github.com/Bluescape/helm/pull/25
This PR fixes a bug of the absence of necessary labels in the Kubernetes resources to add

TESTED=the new version has been tested on the STG environment using the https://github.com/Bluescape/helm/releases/tag/istio-additions-0.2.2-alpha package