### PR TITLE
NEX-2227 - Adding support for new BanzaiCloud Vault

### DIFF
--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha11
+version: 0.14.0-alpha12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha5
+version: 0.14.0-alpha6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha7
+version: 0.14.0-alpha8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.0-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha3
+version: 0.14.0-alpha4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha12
+version: 0.14.0-alpha13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha2
+version: 0.14.0-alpha3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha13
+version: 0.14.0-alpha14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 1.17.0

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha8
+version: 0.14.0-alpha9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha1
+version: 0.14.0-alpha2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha9
+version: 0.14.0-alpha10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha4
+version: 0.14.0-alpha5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha6
+version: 0.14.0-alpha7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha15
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha10
+version: 0.14.0-alpha11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/Chart.yaml
+++ b/charts/bluescape-eks-aux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0-alpha14
+version: 0.14.0-alpha15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-eks-aux/templates/external-secret-aes-edge-stack.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-aes-edge-stack.yaml
@@ -14,3 +14,24 @@ spec:
       key: secret/data/aes-edge-stack
       property: license-key
 {{- end }}
+
+{{- if .Values.external_secrets_operator.setup_aes_edge_stack_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: {{ if eq .Values.external_secrets_operator.aes_edge_stack_secret_name "" }}{{ .Release.Name }}{{ else }}{{ .Values.external_secrets_operator.aes_edge_stack_secret_name }}{{ end }}
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: {{ if eq .Values.external_secrets_operator.aes_edge_stack_secret_name "" }}{{ .Release.Name }}{{ else }}{{ .Values.external_secrets_operator.aes_edge_stack_secret_name }}{{ end }}
+  data:
+  - secretKey: license-key
+    remoteRef:
+      key: aes-edge-stack
+      property: license-key
+{{- end }}
+

--- a/charts/bluescape-eks-aux/templates/external-secret-aes-edge-stack.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-aes-edge-stack.yaml
@@ -20,6 +20,7 @@ apiVersion: 'external-secrets.io/v1beta1'
 kind: 'ExternalSecret'
 metadata:
   name: {{ if eq .Values.external_secrets_operator.aes_edge_stack_secret_name "" }}{{ .Release.Name }}{{ else }}{{ .Values.external_secrets_operator.aes_edge_stack_secret_name }}{{ end }}
+  namespace: {{ if eq .Values.external_secrets_operator.aes_edge_stack_secret_name "" }}{{ .Release.Name }}{{ else }}{{ .Values.external_secrets_operator.aes_edge_stack_secret_name }}{{ end }}
   labels:
     {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
 spec:

--- a/charts/bluescape-eks-aux/templates/external-secret-argocd.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-argocd.yaml
@@ -21,3 +21,31 @@ spec:
       key: secret/data/argocd
       property: serverSecretKey
 {{- end }}
+{{- if .Values.external_secrets_operator.setup_argocd_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "argocd-secret"
+  namespace: argocd
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: argocd-secret
+  data:
+  - secretKey: oidc.dex.clientId
+    remoteRef:
+      key: {{ .Values.external_secrets_operator.argocd_secret_oidc_vault_key }}/dex
+      property: clientId
+  - secretKey: oidc.dex.clientSecret
+    remoteRef:
+      key: {{ .Values.external_secrets_operator.argocd_secret_oidc_vault_key }}/dex
+      property: clientSecret
+  - secretKey: server.secretkey
+    remoteRef:
+      key: argocd
+      property: serverSecretKey
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
@@ -35,10 +35,10 @@ spec:
   data:
   - secretKey: accessKeyId
     remoteRef:
-      key: {{ .Values.external_secrets_operator.cluster_issuer_name }}/aws-route53-creds
+      key: certmanager/{{ .Values.external_secrets_operator.cluster_issuer_name }}/aws-route53-creds
       property: accessKeyId
   - secretKey: secretAccessKey
     remoteRef:
-      key: {{ .Values.external_secrets_operator.cluster_issuer_name }}/aws-route53-creds
+      key: certmanager/{{ .Values.external_secrets_operator.cluster_issuer_name }}/aws-route53-creds
       property: secretAccessKey
 {{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
@@ -22,7 +22,7 @@ spec:
 apiVersion: 'external-secrets.io/v1beta1'
 kind: 'ExternalSecret'
 metadata:
-  name: "cert-manager"
+  name: "{{ .Values.external_secrets_operator.cluster_issuer_name }}"
   namespace: cert-manager
   labels:
     {{- include "bluescape-eks-aux.labels" . | nindent 4 }}

--- a/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
@@ -18,3 +18,27 @@ spec:
       key: secret/data/certmanager/{{ .Values.external_secrets.cluster_issuer_name }}/aws-route53-creds
       property: secretAccessKey
 {{- end }}
+{{- if .Values.external_secrets_operator.setup_legacy_extra_cluster_issuer_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "cert-manager"
+  namespace: cert-manager
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: argocd-secret
+  data:
+  - secretKey: accessKeyId
+    remoteRef:
+      key: {{ .Values.external_secrets_operator.cluster_issuer_name }}/aws-route53-creds
+      property: accessKeyId
+  - secretKey: secretAccessKey
+    remoteRef:
+      key: {{ .Values.external_secrets_operator.cluster_issuer_name }}/aws-route53-creds
+      property: secretAccessKey
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-extra-cluster-issuer.yaml
@@ -31,7 +31,7 @@ spec:
     name: vault-backend-cs
     kind: ClusterSecretStore
   target:
-    name: argocd-secret
+    name: "{{ .Values.external_secrets_operator.cluster_issuer_name }}"
   data:
   - secretKey: accessKeyId
     remoteRef:

--- a/charts/bluescape-eks-aux/templates/external-secret-github.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-github.yaml
@@ -15,3 +15,24 @@ spec:
       key: secret/data/token/github
       property: sshPrivateKey
 {{- end }}
+
+{{- if .Values.external_secrets_operator.setup_github_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "github"
+  namespace: argocd
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: "github"
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: token/github
+      property: sshPrivateKey
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-gpm.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-gpm.yaml
@@ -18,3 +18,28 @@ spec:
       name: oidc.dex.clientSecret
       property: clientSecret
 {{- end }}
+
+{{- if .Values.external_secrets_operator.setup_gatekeeper_policy_manager_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "gpm-secrets"
+  namespace: "gatekeeper-policy-manager"
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: "gpm-secrets"
+  data:
+  - secretKey: oidc.dex.clientId
+    remoteRef:
+      key: oidc/dex
+      property: clientId
+  - secretKey: oidc.dex.clientSecret
+    remoteRef:
+      key: oidc/dex
+      property: clientSecret
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-loki-basic-auth.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-loki-basic-auth.yaml
@@ -18,3 +18,28 @@ spec:
       key: secret/data/logging/loki
       property: password
 {{- end }}
+
+{{- if .Values.external_secrets_operator.setup_loki_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "loki-basic-auth"
+  namespace: "loki"
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: "loki-ingress-auth"
+  data:
+  - secretKey: loki_username
+    remoteRef:
+      key: logging/loki
+      property: username
+  - secretKey: loki_password
+    remoteRef:
+      key: logging/loki
+      property: password
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-loki-ingress-auth.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-loki-ingress-auth.yaml
@@ -15,3 +15,24 @@ spec:
       key: secret/data/logging/loki
       property: ingress-auth
 {{- end }}
+
+{{- if .Values.external_secrets_operator.setup_loki_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "loki-ingress-auth"
+  namespace: "loki"
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: "loki-ingress-auth"
+  data:
+  - secretKey: auth
+    remoteRef:
+      key: logging/loki
+      property: ingress-auth
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-prometheus-metrics.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-prometheus-metrics.yaml
@@ -18,3 +18,27 @@ spec:
       key: secret/data/prometheus/metrics
       property: username
 {{- end }}
+{{- if .Values.external_secrets_operator.setup_prometheus_metrics_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "metrics"
+  namespace: "monitoring"
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: "metrics"
+  data:
+  - secretKey: password
+    remoteRef:
+      key: prometheus/metrics
+      property: password
+  - secretKey: username
+    remoteRef:
+      key: prometheus/metrics
+      property: username
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/external-secret-threatstack.yaml
+++ b/charts/bluescape-eks-aux/templates/external-secret-threatstack.yaml
@@ -15,3 +15,24 @@ spec:
       key: secret/data/threatstack/licensekey
       property: licensekey
 {{- end }}
+
+{{- if .Values.external_secrets_operator.setup_threatstack_secret }}
+apiVersion: 'external-secrets.io/v1beta1'
+kind: 'ExternalSecret'
+metadata:
+  name: "threatstack"
+  namespace: "threatstack"
+  labels:
+    {{- include "bluescape-eks-aux.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: vault-backend-cs
+    kind: ClusterSecretStore
+  target:
+    name: "threatstack"
+  data:
+  - secretKey: licensekey
+    remoteRef:
+      key: threatstack/licensekey
+      property: licensekey
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/vault-backend-cs.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-backend-cs.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.vault_cr.setup_vault_as_cluster_secret_store }}
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: vault-backend-cs
+  namespace: vault
+spec:
+  provider:
+    vault:
+       caProvider:
+        type: "Secret"
+        namespace: vault
+        name: "vault-tls"
+        key: "server.crt"
+       server: "{{ .Values.vault_cr.local_vault_addr }}"
+       path: "secret"
+       version: "v2"
+       auth:
+         kubernetes:
+           mountPath: "kubernetes"
+           role: "default"
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.vault_cr.enabled }}
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name:  "vault"
+  namespace: vault
+  app: vault
+spec:
+  size: "{{ .Values.vault_cr.clusterSize }}"
+  image: "{{ .Values.vault_cr.image }}:{{ .Values.vault_cr.imageTag }}"
+  bankVaultsImage: banzaicloud/bank-vaults:latest
+
+  annotations:
+    common/annotation: 'true'
+  vaultAnnotations:
+    type/instance: "vault"
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
+  vaultLabels:
+    bluescape.com/log-format: json
+  vaultConfigurerLabels:
+    bluescape.com/log-format: string
+
+  vaultPodSpec:
+    priorityClassName: system-node-critical
+  vaultConfigurerPodSpec:
+    priorityClassName: system-node-critical
+
+  serviceAccount: vault
+  serviceType: ClusterIP
+  volumeClaimTemplates:
+    - metadata:
+        name: vault-raft
+      spec:
+        storageClassName: "{{ .Values.vault_cr.storageClass }}"
+        accessModes:
+          - ReadWriteOnce
+        volumeMode: Filesystem
+        resources:
+          requests:
+            storage: 1Gi
+  volumeMounts:
+    - name: vault-raft
+      mountPath: /vault/file
+  veleroEnabled: true
+
+  caNamespaces:
+    - "*"
+  unsealConfig:
+    options:
+      preFlightChecks: true
+    kubernetes:
+      secretnamespace: vault
+
+  config:
+    storage:
+      raft:
+        path: "/vault/file"
+    listener:
+      tcp:
+        address: "0.0.0.0:8200"
+        tls_cert_file: "/vault/tls/server.crt"
+        tls_key_file: "/vault/tls/server.key"
+    api_addr: "https://vault.vault.svc.cluster.local:8200"
+    cluster_addr: "https://${.Env.POD_NAME}:8201"
+    ui: true
+
+  statsdDisabled: true
+  serviceRegistrationEnabled: true
+
+  resources:
+    vault:
+      limits:
+        cpu: 2
+        memory: 1Gi
+      requests:
+        cpu: 1
+        memory: 512Mi
+
+  externalConfig:
+    policies:
+      - name: allow_secrets
+        rules: path "secret/*" {
+          capabilities = ["create", "read", "update", "delete", "list"]
+          }
+    auth:
+      - type: kubernetes
+        roles:
+          # Allow every pod in the default namespace to use the secret kv store
+          - name: default
+            bound_service_account_names:
+              {{- range .Values.vault_cr.bound_service_account_names }}
+              - {{ . }}
+              {{- end }}
+            bound_service_account_namespaces:
+              {{- range .Values.vault_cr.bound_service_account_namespaces }}
+              - {{ . }}
+              {{- end }}
+            policies: allow_secrets
+            ttl: 1h
+          - name: secretsmutation
+            bound_service_account_names:
+              - lacework
+              - vault-secrets-webhook
+            bound_service_account_namespaces:
+              - lacework
+              - vault-secrets-webhook
+            policies:
+              - allow_secrets
+            ttl: 1h
+    secrets:
+      - path: secret
+        type: kv
+        description: General secrets.
+        options:
+          version: 2
+  vaultEnvsConfig:
+    - name: VAULT_LOG_LEVEL
+      value: debug
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: "spot"
+            operator: In
+            values: [ "false" ]
+          - key: "dedicated"
+            operator: NotIn
+            values:
+              - loki
+              - cortex
+              - prometheus
+              - edge
+  podAntiAffinity: failure-domain.beta.kubernetes.io/zone
+{{- end }}

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -4,7 +4,8 @@ kind: "Vault"
 metadata:
   name:  "vault"
   namespace: vault
-  app: vault
+  labels:
+    app: vault
 spec:
   size: "{{ .Values.vault_cr.clusterSize }}"
   image: "{{ .Values.vault_cr.image }}:{{ .Values.vault_cr.imageTag }}"

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -66,7 +66,7 @@ spec:
     options:
       preFlightChecks: true
     kubernetes:
-      secretNamespace: default
+      secretNamespace: vault
 
   config:
     storage:

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -51,7 +51,7 @@ spec:
     options:
       preFlightChecks: true
     kubernetes:
-      secretnamespace: vault
+      secretNamespace: vault
 
   config:
     storage:

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -11,6 +11,22 @@ spec:
   image: "{{ .Values.vault_cr.image }}:{{ .Values.vault_cr.imageTag }}"
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
+  podAntiAffinity: failure-domain.beta.kubernetes.io/zone
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "spot"
+                operator: In
+                values: [ "false" ]
+              - key: "dedicated"
+                operator: NotIn
+                values:
+                  - loki
+                  - cortex
+                  - prometheus
+                  - edge
   annotations:
     common/annotation: 'true'
   vaultAnnotations:
@@ -23,11 +39,11 @@ spec:
     bluescape.com/log-format: string
 
   vaultPodSpec:
-    priorityClassName: system-node-critical
+    priorityClassName: "{{ .Values.vault_cr.priorityClassName }}"
   vaultConfigurerPodSpec:
-    priorityClassName: system-node-critical
+    priorityClassName: "{{ .Values.vault_cr.priorityClassName }}"
 
-  serviceAccount: vault
+  serviceAccount: "{{ .Values.vault_cr.serviceAccount }}"
   serviceType: ClusterIP
   volumeClaimTemplates:
     - metadata:
@@ -60,9 +76,10 @@ spec:
     listener:
       tcp:
         address: "0.0.0.0:8200"
+        tls_disable: {{ .Values.vault_cr.tls_disable }}
         tls_cert_file: "/vault/tls/server.crt"
         tls_key_file: "/vault/tls/server.key"
-    api_addr: "https://vault.vault.svc.cluster.local:8200"
+    api_addr: "{{ .Values.vault_cr.local_vault_addr }}"
     cluster_addr: "https://${.Env.POD_NAME}:8201"
     ui: true
 
@@ -118,21 +135,4 @@ spec:
   vaultEnvsConfig:
     - name: VAULT_LOG_LEVEL
       value: debug
-
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: "spot"
-            operator: In
-            values: [ "false" ]
-          - key: "dedicated"
-            operator: NotIn
-            values:
-              - loki
-              - cortex
-              - prometheus
-              - edge
-  podAntiAffinity: failure-domain.beta.kubernetes.io/zone
 {{- end }}

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -131,7 +131,29 @@ spec:
         description: General secrets.
         options:
           version: 2
+      - type: pki
+        description: Vault PKI Backend
+        config:
+          default_lease_ttl: 168h
+          max_lease_ttl: 720h
+        configuration:
+          config:
+            - name: urls
+              issuing_certificates: "{{ .Values.vault_cr.local_vault_addr }}/v1/pki/ca"
+              crl_distribution_points: "{{ .Values.vault_cr.local_vault_addr }}/v1/pki/crl"
+          root/generate:
+            - name: internal
+              common_name: vault.vault
+          roles:
+            - name: default
+              allowed_domains: localhost,pod,svc,vault
+              allow_subdomains: true
+              generate_lease: true
+              ttl: 1m
+
   vaultEnvsConfig:
     - name: VAULT_LOG_LEVEL
       value: debug
+
+  istioEnabled: {{ .Values.vault_cr.istio_enable }}
 {{- end }}

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -4,12 +4,9 @@ kind: "Vault"
 metadata:
   name:  "vault"
   namespace: vault
-  labels:
-    app: vault
 spec:
   size: {{ .Values.vault_cr.clusterSize }}
   image: "{{ .Values.vault_cr.image }}:{{ .Values.vault_cr.imageTag }}"
-  bankVaultsImage: banzaicloud/bank-vaults:latest
 
   podAntiAffinity: failure-domain.beta.kubernetes.io/zone
   affinity:
@@ -45,6 +42,7 @@ spec:
 
   serviceAccount: "{{ .Values.vault_cr.serviceAccount }}"
   serviceType: ClusterIP
+
   volumeClaimTemplates:
     - metadata:
         name: vault-raft
@@ -63,11 +61,12 @@ spec:
 
   caNamespaces:
     - "*"
+
   unsealConfig:
     options:
       preFlightChecks: true
     kubernetes:
-      secretNamespace: vault
+      secretNamespace: default
 
   config:
     storage:

--- a/charts/bluescape-eks-aux/templates/vault-cr.yaml
+++ b/charts/bluescape-eks-aux/templates/vault-cr.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: vault
 spec:
-  size: "{{ .Values.vault_cr.clusterSize }}"
+  size: {{ .Values.vault_cr.clusterSize }}
   image: "{{ .Values.vault_cr.image }}:{{ .Values.vault_cr.imageTag }}"
   bankVaultsImage: banzaicloud/bank-vaults:latest
 

--- a/charts/bluescape-eks-aux/values.yaml
+++ b/charts/bluescape-eks-aux/values.yaml
@@ -15,6 +15,15 @@ vault:
   bound_service_account_names: []
   bound_service_account_namespaces: []
 
+vault_cr:
+  enabled: false
+  image: vault
+  imageTag: "1.6.0"
+  bound_service_account_names: []
+  bound_service_account_namespaces: []
+  storageClass: "persistent"
+  clusterSize: "3"
+
 cert_manager:
   setup_letsencrypt_prod_cluster_issuer: false
   setup_letsencrypt_prod_cluster_dns_issuer: false

--- a/charts/bluescape-eks-aux/values.yaml
+++ b/charts/bluescape-eks-aux/values.yaml
@@ -23,6 +23,10 @@ vault_cr:
   bound_service_account_namespaces: []
   storageClass: "persistent"
   clusterSize: 3
+  serviceAccount: "vault"
+  priorityClassName: "system-node-critical"
+  tls_disable: false
+  local_vault_addr: "https://vault.vault.svc.cluster.local:8200"
 
 cert_manager:
   setup_letsencrypt_prod_cluster_issuer: false

--- a/charts/bluescape-eks-aux/values.yaml
+++ b/charts/bluescape-eks-aux/values.yaml
@@ -28,6 +28,7 @@ vault_cr:
   tls_disable: false
   istio_enable: false
   local_vault_addr: "https://vault.vault.svc.cluster.local:8200"
+  setup_vault_as_cluster_secret_store: false
 
 cert_manager:
   setup_letsencrypt_prod_cluster_issuer: false

--- a/charts/bluescape-eks-aux/values.yaml
+++ b/charts/bluescape-eks-aux/values.yaml
@@ -26,6 +26,7 @@ vault_cr:
   serviceAccount: "vault"
   priorityClassName: "system-node-critical"
   tls_disable: false
+  istio_enable: false
   local_vault_addr: "https://vault.vault.svc.cluster.local:8200"
 
 cert_manager:

--- a/charts/bluescape-eks-aux/values.yaml
+++ b/charts/bluescape-eks-aux/values.yaml
@@ -22,7 +22,7 @@ vault_cr:
   bound_service_account_names: []
   bound_service_account_namespaces: []
   storageClass: "persistent"
-  clusterSize: "3"
+  clusterSize: 3
 
 cert_manager:
   setup_letsencrypt_prod_cluster_issuer: false

--- a/charts/bluescape-eks-aux/values.yaml
+++ b/charts/bluescape-eks-aux/values.yaml
@@ -68,3 +68,20 @@ kubedb_catalog:
   setup_mysql_5_6: false
   setup_postgres_11_1: false
 
+external_secrets_operator:
+  setup_cluster_secret_store_for_vault: false
+
+  setup_legacy_extra_cluster_issuer_secret: false
+  cluster_issuer_name: ""
+
+  setup_gatekeeper_policy_manager_secret: false
+  setup_prometheus_metrics_secret: false
+  setup_threatstack_secret: false
+  setup_argocd_secret: false
+  setup_github_secret: false
+  setup_loki_secret: false
+
+  setup_aes_edge_stack_secret: false
+  aes_edge_stack_secret_name: ""
+
+  argocd_secret_oidc_vault_key: oidc


### PR DESCRIPTION
**Target Chart Version : 0.15.0**

- New Vault (HA, raft storage) - provisioned from EKS project. 
```
vault_cr:
  enabled: false
  image: vault
  imageTag: "1.6.0"
  bound_service_account_names: []
  bound_service_account_namespaces: []
  storageClass: "persistent"
  clusterSize: 3
  serviceAccount: "vault"
  priorityClassName: "system-node-critical"
  tls_disable: false
  istio_enable: false
  local_vault_addr: "https://vault.vault.svc.cluster.local:8200"
  setup_vault_as_cluster_secret_store: false
```
- Adding support for NEW external-secrets-operator and vault-backed via `ClusterSecretStore`
- New manifests for secrets synced via `external-secrets-operator`