### PR TITLE
NEX-2318: Add preflight check for chart version updates

### DIFF
--- a/.github/scripts/verify_chart_version_update.sh
+++ b/.github/scripts/verify_chart_version_update.sh
@@ -1,0 +1,28 @@
+pushd ../../charts
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Get all charts that were modified
+modified_charts=($(git diff --name-only origin/main...HEAD -- './**/templates/**/*.yaml' | cut -d/ -f 2 | xargs))
+
+# Remove duplicate charts
+uq_modified_charts=($(for chart in "${modified_charts[@]}"; do echo "${chart}"; done | sort -u))
+
+for chart in ${uq_modified_charts[@]}; do
+  chart_file=./$chart/Chart.yaml
+  # Get chart version from this branch
+  new_version=$(cat $chart_file | yq '.version')
+  # Get chart version from main branch
+  main_version=$(git show origin/main:$chart_file | yq '.version')
+
+  # Compare them to make sure they aren't equal after a change
+  echo "Chart changed $chart..."
+  echo "New Chart Version: $new_version"
+  echo "Checked in Chart Version: $main_version"
+
+  if [[ "$new_version" == "$main_version" ]]; then
+    echo -e "${RED}ERROR:${NC} Chart version hasn't changed with an update to the chart"
+    exit 1
+  fi
+done

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Preflight
 
 on:
   pull_request:
@@ -19,3 +19,15 @@ jobs:
       - name: Run Lint
         working-directory: ./charts
         run: helm lint *
+
+  chart_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check Versions
+        working-directory: .github/scripts
+        run: |
+          ./verify_chart_version_update.sh


### PR DESCRIPTION
## Description
Check added in preflight to verify that the version of the chart has been updated whenever the chart yaml has been. 

## Testing
Run when the chart version wasn't modified: https://github.com/Bluescape/helm/actions/runs/3282901673/jobs/5406925600
Fails as expected

Run where the chart version was modified: https://github.com/Bluescape/helm/actions/runs/3282916555/jobs/5406961212
Passes as expected