### PR TITLE
SRE-1945 - image we were using was vulnerable to openssl vuln. Updati…

### DIFF
--- a/charts/bluescape-lacework-agent/Chart.yaml
+++ b/charts/bluescape-lacework-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.2"
 description: Lacework Agent
 home: https://www.lacework.com
 icon: https://www.lacework.com/wp-content/uploads/2019/07/Lacework_Logo_color_2019.svg
@@ -15,4 +15,4 @@ maintainers:
 - email: info@lacework.net
   name: lacework-support
 name: lacework-agent
-version: 5.0.0
+version: 6.1.2

--- a/charts/bluescape-lacework-agent/values.yaml
+++ b/charts/bluescape-lacework-agent/values.yaml
@@ -3,7 +3,7 @@
 image:
   registry: docker.io
   repository: lacework/datacollector
-  tag: 5.0.0
+  tag: 6.1.2
 
   # imagePullPolicy should be Always to get the latest container
   # http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
…ng to recommendded image tag

IAW https://docs.lacework.com/critical-openssl-vulnerability-linux-agent#upgrade-the-lacework-linux-agent-docker-image?utm_source=marketo&utm_medium=email&utm_campaign=20221103_GLO_EMS_OpenSSL_Vulnerability

Signed-off-by: Jim Conner <snafu.x@gmail.com>