### PR TITLE
SRE-1914 - Adding new grafana dashboard for backend rendering api

### DIFF
--- a/charts/bluescape-monitoring-dashboards/Chart.yaml
+++ b/charts/bluescape-monitoring-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.31
+version: 0.2.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
@@ -46,12 +46,37 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
               },
               "custom": {
-                "align": "auto",
-                "displayMode": "auto",
-                "inspect": false
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -68,20 +93,7 @@ data:
                 ]
               }
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "labels"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 643
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -91,15 +103,16 @@ data:
           },
           "id": 9,
           "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showHeader": true,
-            "sortBy": []
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
           },
           "pluginVersion": "9.1.4",
           "targets": [
@@ -116,7 +129,7 @@ data:
             }
           ],
           "title": "Backend Rendering - captureRender timeouts",
-          "type": "table"
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -601,13 +614,13 @@ data:
         ]
       },
       "time": {
-        "from": "2022-12-09T08:31:08.517Z",
-        "to": "2022-12-10T05:07:37.317Z"
+        "from": "2022-12-02T18:30:00.000Z",
+        "to": "2022-12-15T18:29:59.000Z"
       },
       "timepicker": {},
       "timezone": "",
       "title": "Backend Rendering API",
       "uid": "4AUVuBK4z",
-      "version": 19,
+      "version": 20,
       "weekStart": ""
     }

--- a/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
@@ -1,0 +1,612 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-rendering-api-dashboard
+  namespace: grafana
+  labels:
+     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
+data:
+  backend-rendering-api-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 78,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "labels"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 643
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 9,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({component=\"browser-service\"} |= \"Backend Rendering\" |= \"captureRender: timeout occurred\" [1h]))",
+              "hide": false,
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Backend Rendering - captureRender timeouts, last hour",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({component=\"browser-service\"} |= \"Backend Rendering\" |= \"captureRender: timeout occurred\" [1h]))",
+              "hide": false,
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Backend Rendering - captureRender timeouts, last hour",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({namespace=~\"$namespace\"} |= \"Backend Rendering\" |= \"render success\" [1h]))",
+              "legendFormat": "Render Success",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Backend Rendering - Render Success - Last 1 hour",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({ component=\"browser-service\" } |~\"\\\"level\\\":60\" [1h]))",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Browser-service, errors level 60, last 1 hour",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({ component=\"browser-service\" } |~\"\\\"level\\\":50\" [1h]))",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Browser-service, errors level 50, last 1 hour",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 4,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "9.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "{component=\"browser-service\"} |~\"level\\\":[5,6]0\"",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Browser Service errors (level 50 and 60)",
+          "type": "table"
+        }
+      ],
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": true,
+              "text": "loki-stg1",
+              "value": "loki-stg1"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "loki",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "stg1",
+              "value": "stg1"
+            },
+            "datasource": {
+              "type": "loki",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(namespace)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-2d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Backend Rendering API",
+      "uid": "4AUVuBK4z",
+      "version": 17,
+      "weekStart": ""
+    }

--- a/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
@@ -115,7 +115,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Backend Rendering - captureRender timeouts, last hour",
+          "title": "Backend Rendering - captureRender timeouts",
           "type": "table"
         },
         {
@@ -208,7 +208,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Backend Rendering - captureRender timeouts, last hour",
+          "title": "Backend Rendering - captureRender timeouts",
           "type": "timeseries"
         },
         {
@@ -300,7 +300,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Backend Rendering - Render Success - Last 1 hour",
+          "title": "Backend Rendering - Render Success",
           "type": "timeseries"
         },
         {
@@ -391,7 +391,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Browser-service, errors level 60, last 1 hour",
+          "title": "Browser-service, errors level 60",
           "type": "timeseries"
         },
         {
@@ -482,7 +482,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Browser-service, errors level 50, last 1 hour",
+          "title": "Browser-service, errors level 50",
           "type": "timeseries"
         },
         {
@@ -551,6 +551,7 @@ data:
           "type": "table"
         }
       ],
+      "refresh": false,
       "schemaVersion": 37,
       "style": "dark",
       "tags": [],
@@ -558,7 +559,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "loki-stg1",
               "value": "loki-stg1"
             },
@@ -600,13 +601,13 @@ data:
         ]
       },
       "time": {
-        "from": "now-2d",
-        "to": "now"
+        "from": "2022-12-09T08:31:08.517Z",
+        "to": "2022-12-10T05:07:37.317Z"
       },
       "timepicker": {},
       "timezone": "",
       "title": "Backend Rendering API",
       "uid": "4AUVuBK4z",
-      "version": 17,
+      "version": 19,
       "weekStart": ""
     }

--- a/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/configmap.yaml
@@ -189,12 +189,12 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
+            "h": 9,
             "w": 12,
             "x": 12,
             "y": 0
           },
-          "id": 10,
+          "id": 7,
           "options": {
             "legend": {
               "calcs": [],
@@ -207,7 +207,6 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "9.1.4",
           "targets": [
             {
               "datasource": {
@@ -215,13 +214,12 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time({component=\"browser-service\"} |= \"Backend Rendering\" |= \"captureRender: timeout occurred\" [1h]))",
-              "hide": false,
+              "expr": "sum(count_over_time({ component=\"browser-service\" } |~\"\\\"level\\\":60\" [1h]))",
               "queryType": "range",
               "refId": "A"
             }
           ],
-          "title": "Backend Rendering - captureRender timeouts",
+          "title": "Browser-service, errors level 60",
           "type": "timeseries"
         },
         {
@@ -324,37 +322,12 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "palette-classic"
+                "mode": "thresholds"
               },
               "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
               },
               "mappings": [],
               "thresholds": {
@@ -374,24 +347,23 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 9,
+            "h": 8,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 9
           },
-          "id": 7,
+          "id": 4,
           "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
             },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
+            "showHeader": true
           },
+          "pluginVersion": "9.1.4",
           "targets": [
             {
               "datasource": {
@@ -399,13 +371,13 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time({ component=\"browser-service\" } |~\"\\\"level\\\":60\" [1h]))",
+              "expr": "{component=\"browser-service\"} |~\"level\\\":[5,6]0\"",
               "queryType": "range",
               "refId": "A"
             }
           ],
-          "title": "Browser-service, errors level 60",
-          "type": "timeseries"
+          "title": "Browser Service errors (level 50 and 60)",
+          "type": "table"
         },
         {
           "datasource": {
@@ -497,71 +469,6 @@ data:
           ],
           "title": "Browser-service, errors level 50",
           "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "displayMode": "auto",
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 17
-          },
-          "id": 4,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
-          },
-          "pluginVersion": "9.1.4",
-          "targets": [
-            {
-              "datasource": {
-                "type": "loki",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "{component=\"browser-service\"} |~\"level\\\":[5,6]0\"",
-              "queryType": "range",
-              "refId": "A"
-            }
-          ],
-          "title": "Browser Service errors (level 50 and 60)",
-          "type": "table"
         }
       ],
       "refresh": false,

--- a/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/dashboard.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: backend-rendering-api-dashboard
+  namespace: grafana
+  labels:
+     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
+spec:
+  json: 
+  configMapRef:
+    name: backend-rendering-api-dashboard
+    key: backend-rendering-api-dashboard.json
+  name: backend-rendering-api-dashboard


### PR DESCRIPTION
Please review and merge the PR for backend rendering api dashboard.
Tested in STG1 environment:
https://grafana.b-stg1.preprod.bluescape.io/d/4AUVuBK4z/backend-rendering-api?orgId=1&from=now-2d&to=now&var-datasource=loki-stg1&var-instance=&var-namespace=stg1
![image](https://user-images.githubusercontent.com/50701092/206384294-96b55e56-06ff-485a-89c0-52b923cd4339.png)
