### PR TITLE
CD-625: Istio-additions Chart Update (for packaging harness)

### DIFF
--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4-alpha1
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/templates/edge-stack-tls-context.yaml
+++ b/charts/istio-additions/templates/edge-stack-tls-context.yaml
@@ -1,0 +1,15 @@
+## Reference : https://www.getambassador.io/docs/edge-stack/latest/topics/running/tls/
+{{- if .Values.edge_stack.setup_tlscontext.enabled }}
+apiVersion: getambassador.io/v2
+kind: TLSContext
+metadata:
+  name: istio-upstream
+  namespace: edge-stack
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
+spec:
+  secret: istio-certs   # This secret name tracks the Istio certificates read from /etc/istio-certs
+  alpn_protocols: istio
+{{- end }}

--- a/charts/istio-additions/templates/edge-stack-tracing-service.yaml
+++ b/charts/istio-additions/templates/edge-stack-tracing-service.yaml
@@ -1,0 +1,19 @@
+## Reference : https://www.getambassador.io/docs/edge-stack/latest/topics/running/services/tracing-service/
+{{- if .Values.edge_stack.setup_tracingservice.enabled }}
+apiVersion: getambassador.io/v2
+kind: TracingService
+metadata:
+  name:  tracing
+  namespace: edge-stack
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    {{- include "istio-additions.labels" . | nindent 4 }}
+spec:
+  service: {{ .Values.edge_stack.setup_tracingservice.tracing_uri }}
+  driver: zipkin
+  config: {}
+  tag_headers:
+    - ":authority"
+    - ":path"
+{{- end }}

--- a/charts/istio-additions/values.yaml
+++ b/charts/istio-additions/values.yaml
@@ -2,7 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-## Ambassador configuration(s) for ServiceMesh
+## edge-stack configuration(s) for ServiceMesh (Used exclusively for packaging)
+edge_stack:
+  setup_tracingservice:
+    enabled: false
+    tracing_uri: 'jaeger-aio-collector.istio-system.svc.cluster.local:9411'
+  setup_tlscontext:
+    enabled: false
+
+## Ambassador configuration(s) for ServiceMesh (To be deprecated, after K8s 1.23+, generated at runtime in TF)
 ambassador:
   setup_tracingservice:
     enabled: false


### PR DESCRIPTION
This change is exclusively required for packaging harness. For all other K8s clusters, this configuration is generated dynamically in TF and applied at runtime.