### PR TITLE
Fix JSON not being assigned to "" in backend-rendering-api-dashboard

### DIFF
--- a/charts/bluescape-monitoring-dashboards/Chart.yaml
+++ b/charts/bluescape-monitoring-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.34
+version: 0.2.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/dashboard.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/84_backend_rendering_api_dashboard/dashboard.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
      {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
 spec:
-  json: 
+  json: ""
   configMapRef:
     name: backend-rendering-api-dashboard
     key: backend-rendering-api-dashboard.json


### PR DESCRIPTION
I believe this was causing issues during the latest base apps run after updating the grafana operator version. 
```
Error: error validating "": error validating data: [ValidationError(GrafanaDashboard.spec): unknown field "name" in org.integreatly.v1alpha1.GrafanaDashboard.spec, ValidationError(GrafanaDashboard.spec): missing required field "json" in org.integreatly.v1alpha1.GrafanaDashboard.spec]
with module.k8s.helm_release.grafana-dashboards[0]
on ../../../../../../modules/helm/k8s-generic/grafana-operator.tf line 272, in resource "helm_release" "grafana-dashboards":
```
Basing this off of KG's changes: https://github.com/Bluescape/helm/commit/0f84c71c62327670b8393f471b488b6df4cdc0f7