### PR TITLE
NEX-2492 - Ability to pass additional environment vars to Grafana instance for custom config

### DIFF
--- a/charts/bluescape-monitoring-grafana/Chart.yaml
+++ b/charts/bluescape-monitoring-grafana/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-monitoring-grafana/templates/grafana-env-secret.yaml
+++ b/charts/bluescape-monitoring-grafana/templates/grafana-env-secret.yaml
@@ -1,0 +1,13 @@
+{{- if gt (len .Values.grafana.env) 0 }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: "{{ .Release.Name }}-grafana-env-vars"
+    labels: {{- include "bluescape-monitoring-grafana.labels" . | nindent 6 }}
+stringData:
+  {{- range $k, $v := .Values.grafana.env }}
+  {{- range $kk, $vv := $v }}
+  {{ $kk }}: "{{ $vv }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/bluescape-monitoring-grafana/templates/grafana.yaml
+++ b/charts/bluescape-monitoring-grafana/templates/grafana.yaml
@@ -15,6 +15,10 @@ items:
             name: postgres-grafana-auth
         - secretRef:
             name: grafana-admin-credentials
+      {{- if gt (len .Values.grafana.env) 0 }}
+        - secretRef:
+            name: "{{ .Release.Name }}-grafana-env-vars"
+      {{- end }}
       {{- if or (eq .Values.sync_credentials.grafana_oidc_secret.via_external_secrets true) (eq .Values.sync_credentials.grafana_oidc_secret.via_external_secrets_operator true) }}
         - secretRef:
             name: grafana-oidc-auth
@@ -31,6 +35,10 @@ items:
     deployment:
       replicas: 1
       envFrom:
+      {{- if gt (len .Values.grafana.env) 0 }}
+        - secretRef:
+            name: "{{ .Release.Name }}-grafana-env-vars"
+      {{- end }}
       {{- if or (eq .Values.sync_credentials.grafana_oidc_secret.via_external_secrets true) (eq .Values.sync_credentials.grafana_oidc_secret.via_external_secrets_operator true) }}
         - secretRef:
             name: grafana-oidc-auth

--- a/charts/bluescape-monitoring-grafana/values.yaml
+++ b/charts/bluescape-monitoring-grafana/values.yaml
@@ -22,6 +22,8 @@ grafana:
   domain_name: example.io
   cluster_id: example
   baseImage: grafana/grafana:8.3.3
+  env: []
+#    - GF_FEATURE_TOGGLES_ENABLE: traceToMetrics,tempoApmTable,traceqlEditor
 
   # Used to pass GF_INSTALL_PLUGINS env var to grafana to install additional plugins on start:
   # https://github.com/grafana-operator/grafana-operator/blob/master/documentation/plugins.md


### PR DESCRIPTION
- Adds ability to send through a list of environment vars to add to the grafana process (disabled by default)