### PR TITLE
FED-941 - Fix kube related metrics

### DIFF
--- a/charts/bluescape-monitoring-dashboards/Chart.yaml
+++ b/charts/bluescape-monitoring-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.16
+version: 0.3.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-monitoring-dashboards/Chart.yaml
+++ b/charts/bluescape-monitoring-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.17
+version: 0.3.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bluescape-monitoring-dashboards/templates/61_k8s-cluster-dashboard/configmap.yaml
+++ b/charts/bluescape-monitoring-dashboards/templates/61_k8s-cluster-dashboard/configmap.yaml
@@ -13,7 +13,10 @@ data:
         "list": [
           {
             "builtIn": 1,
-            "datasource": "-- Grafana --",
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
@@ -29,12 +32,11 @@ data:
         ]
       },
       "description": "Dashboard of use from resource of cluster of Kubernetes.\r\nIn this Dashboard it see:\r\n\r\nState of containers from Cluster, State of Pods from Cluster, State of Jobs from Cluster, Deployment and ReplicationController state of Cluster, Nodes number and state of they, Network Activity by namespaces, CPU use in the cluster and CPU use in the cluster by namespaces, Ram memory use in the cluster and Ram memory use in the cluster by namespaces.",
-      "editable": false,
+      "editable": true,
       "fiscalYearStartMonth": 0,
       "gnetId": 11663,
       "graphTooltip": 1,
-      "id": 66,
-      "iteration": 1654735036950,
+      "id": 82,
       "links": [
         {
           "asDropdown": true,
@@ -52,6 +54,10 @@ data:
       "panels": [
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -60,13 +66,22 @@ data:
           },
           "id": 36,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Containers",
           "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Numbers of containers of cluster in state Running",
           "fieldConfig": {
@@ -126,9 +141,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_container_status_running{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -141,7 +160,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Numbers of containers of cluster in state Terminated",
           "fieldConfig": {
@@ -201,9 +220,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_container_status_terminated{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -216,7 +239,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Numbers of containers of cluster in state Waiting",
           "fieldConfig": {
@@ -276,9 +299,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_container_status_waiting{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -291,7 +318,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Numbers of containers of cluster that restarts in the last 30 minutes",
           "fieldConfig": {
@@ -351,9 +378,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(delta(kube_pod_container_status_restarts_total{namespace!=\"kube-system\"}[30m]))",
               "format": "time_series",
               "intervalFactor": 1,
@@ -366,6 +397,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -374,13 +409,22 @@ data:
           },
           "id": 28,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Pods",
           "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Percentage of possible Pods use in the Cluster",
           "fieldConfig": {
@@ -443,12 +487,18 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "sum(kube_pod_info) / sum(kube_node_status_allocatable_pods) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_info) / sum(kube_node_status_allocatable{resource = \"pods\"}) * 100",
               "format": "time_series",
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -462,7 +512,7 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Graph of Pods use in the cluster",
           "fill": 1,
@@ -492,7 +542,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -502,6 +552,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_node_status_allocatable_pods)",
               "format": "time_series",
               "intervalFactor": 1,
@@ -509,6 +563,10 @@ data:
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_node_status_capacity_pods)",
               "format": "time_series",
               "intervalFactor": 1,
@@ -516,6 +574,10 @@ data:
               "refId": "B"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_info)",
               "format": "time_series",
               "intervalFactor": 1,
@@ -539,12 +601,14 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:63",
               "format": "short",
               "label": "pods",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:64",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -557,7 +621,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Pods in state Running",
           "fieldConfig": {
@@ -617,9 +681,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"})",
               "format": "time_series",
               "interval": "",
@@ -633,7 +701,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Pods in state Pending",
           "fieldConfig": {
@@ -693,9 +761,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Pending\"})",
               "format": "time_series",
               "interval": "",
@@ -709,7 +781,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Pods in state Failed",
           "fieldConfig": {
@@ -769,9 +841,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Failed\"})",
               "format": "time_series",
               "interval": "",
@@ -785,7 +861,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Pods in state Succeeded",
           "fieldConfig": {
@@ -845,9 +921,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Succeeded\"})",
               "format": "time_series",
               "interval": "",
@@ -861,7 +941,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Pods in state Unknown",
           "fieldConfig": {
@@ -921,9 +1001,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Unknown\"})",
               "format": "time_series",
               "interval": "",
@@ -936,6 +1020,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -944,13 +1032,22 @@ data:
           },
           "id": 45,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Jobs",
           "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Succeeded Jobs",
           "fieldConfig": {
@@ -1010,9 +1107,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1025,7 +1126,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Active Jobs",
           "fieldConfig": {
@@ -1085,9 +1186,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_job_status_active{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1100,7 +1205,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Failed Jobs",
           "fieldConfig": {
@@ -1160,9 +1265,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1174,6 +1283,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1182,19 +1295,29 @@ data:
           },
           "id": 14,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Deploy & RC",
           "type": "row"
         },
         {
           "columns": [
             {
+              "$$hashKey": "object:125",
               "text": "Current",
               "value": "current"
             }
           ],
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "List of Deployment with it number of replicas",
           "fontSize": "100%",
@@ -1214,6 +1337,7 @@ data:
           },
           "styles": [
             {
+              "$$hashKey": "object:127",
               "alias": "Time",
               "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -1221,6 +1345,7 @@ data:
               "type": "hidden"
             },
             {
+              "$$hashKey": "object:128",
               "alias": "",
               "align": "auto",
               "colorMode": "row",
@@ -1240,6 +1365,7 @@ data:
               "unit": "none"
             },
             {
+              "$$hashKey": "object:129",
               "alias": "",
               "align": "auto",
               "colorMode": "row",
@@ -1262,12 +1388,16 @@ data:
           ],
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "kube_deployment_status_replicas{namespace=~\"$namespace\"}",
               "format": "time_series",
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{ deployment }}` }}",
+              "legendFormat": "{{`{{ deployment }}`}}",
               "refId": "A"
             }
           ],
@@ -1278,7 +1408,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number replicas of Deployment with state Available",
           "fieldConfig": {
@@ -1338,9 +1468,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_deployment_status_replicas{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1354,7 +1488,7 @@ data:
           "columns": [],
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "List of Replication Controller with it number of replicas",
           "fontSize": "100%",
@@ -1374,6 +1508,7 @@ data:
           },
           "styles": [
             {
+              "$$hashKey": "object:196",
               "alias": "Time",
               "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -1381,6 +1516,7 @@ data:
               "type": "hidden"
             },
             {
+              "$$hashKey": "object:197",
               "alias": "Replication Controller",
               "align": "auto",
               "colorMode": "cell",
@@ -1399,6 +1535,7 @@ data:
               "unit": "short"
             },
             {
+              "$$hashKey": "object:198",
               "alias": "Value",
               "align": "auto",
               "colorMode": "cell",
@@ -1418,6 +1555,7 @@ data:
               "unit": "short"
             },
             {
+              "$$hashKey": "object:199",
               "alias": "",
               "align": "auto",
               "colors": [
@@ -1434,6 +1572,11 @@ data:
           ],
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
               "expr": "kube_replicationcontroller_status_replicas{namespace=~\"$namespace\"}",
               "format": "table",
               "hide": false,
@@ -1449,7 +1592,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number replicas of Replication Controller with state Available",
           "fieldConfig": {
@@ -1509,9 +1652,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_replicationcontroller_status_replicas{namespace=~\"$namespace\"})",
               "format": "time_series",
               "instant": false,
@@ -1525,7 +1672,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number replicas of Deployment with state Unavailable",
           "fieldConfig": {
@@ -1585,9 +1732,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1600,7 +1751,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number replicas of Replication Controller with state Unavailable",
           "fieldConfig": {
@@ -1660,9 +1811,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_replicationcontroller_spec_replicas{namespace=~\"$namespace\"})\n-\nsum(kube_replicationcontroller_status_replicas{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1675,7 +1830,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Total number replicas of Deployment",
           "fieldConfig": {
@@ -1736,9 +1891,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_deployment_spec_replicas{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1751,7 +1910,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Total number replicas of Replication Controller",
           "fieldConfig": {
@@ -1811,9 +1970,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_replicationcontroller_spec_replicas{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1825,6 +1988,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1833,13 +2000,22 @@ data:
           },
           "id": 22,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Node",
           "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Nodes with Out of Disk",
           "fieldConfig": {
@@ -1901,9 +2077,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_node_status_condition{condition=\"OutOfDisk\", status=\"true\"})",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1916,7 +2096,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Nodes Available",
           "fieldConfig": {
@@ -1975,9 +2155,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_node_info)",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1990,7 +2174,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Number of Nodes Unavailable",
           "fieldConfig": {
@@ -2052,9 +2236,13 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(kube_node_spec_unschedulable)",
               "format": "time_series",
               "intervalFactor": 1,
@@ -2066,6 +2254,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -2074,6 +2266,15 @@ data:
           },
           "id": 68,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Network Cluster",
           "type": "row"
         },
@@ -2084,17 +2285,19 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "decimals": 2,
           "description": "Network Activity by Namespaces",
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 24,
             "x": 0,
             "y": 35
           },
+          "hiddenSeries": false,
           "id": 70,
           "legend": {
             "alignAsTable": true,
@@ -2114,8 +2317,11 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2125,23 +2331,32 @@ data:
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "sum(rate(container_network_receive_bytes_total{}[2m])) by (namespace)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{namespace}}` }}",
+              "legendFormat": "{{`{{namespace}}`}}",
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "expr": "- sum (rate (container_network_transmit_bytes_total{}[2m])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{namespace}}` }}",
+              "legendFormat": "{{`{{namespace}}`}}",
               "refId": "B"
             }
           ],
           "thresholds": [],
+          "timeRegions": [],
           "title": "Network I/O",
           "tooltip": {
             "shared": true,
@@ -2156,12 +2371,14 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:393",
               "decimals": 1,
               "format": "decbytes",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:394",
               "format": "short",
               "logBase": 1,
               "show": false
@@ -2173,6 +2390,10 @@ data:
         },
         {
           "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -2181,13 +2402,22 @@ data:
           },
           "id": 2,
           "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "Cluster Health",
           "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Percent of use of CPU resource request in the Cluster",
           "fieldConfig": {
@@ -2250,13 +2480,19 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "max(sum(kube_pod_container_resource_requests_cpu_cores) by (instance)) / min(sum(kube_node_status_allocatable_cpu_cores) by (instance)) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "max(sum(kube_pod_container_resource_requests{resource=\"cpu\"}) by (instance)) / min(sum(kube_node_status_allocatable{resource=\"cpu\"}) by (instance)) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -2266,7 +2502,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Percent of use of CPU resource limit in the Cluster",
           "fieldConfig": {
@@ -2329,13 +2565,19 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "max(sum(kube_pod_container_resource_limits_cpu_cores) by (instance))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "max(sum(kube_pod_container_resource_limits{resource=\"cpu\"}) by (instance))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -2345,7 +2587,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Cluster CPU usage (2m)",
           "fieldConfig": {
@@ -2396,7 +2638,7 @@ data:
             "colorMode": "none",
             "graphMode": "area",
             "justifyMode": "auto",
-            "orientation": "horizontal",
+            "orientation": "auto",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -2406,14 +2648,20 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "SUM(irate(container_cpu_usage_seconds_total{id=\"/\"}[2m]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(irate(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate [2m] ))",
               "format": "time_series",
               "interval": "5m",
               "intervalFactor": 1,
               "legendFormat": "",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -2427,17 +2675,19 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "decimals": 2,
           "description": "CPU Use of node by namespace",
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 12,
             "y": 46
           },
+          "hiddenSeries": false,
           "id": 61,
           "legend": {
             "alignAsTable": true,
@@ -2455,8 +2705,11 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2466,14 +2719,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum (rate (container_cpu_usage_seconds_total{pod_name!=\"\",container_name!=\"POD\"}[10m]) * 100) by (namespace) / scalar(sum(machine_cpu_cores))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate (container_cpu_usage_seconds_total{pod!=\"\",name!=\"POD\"}[10m]) * 100) by (namespace) / scalar(sum(machine_cpu_cores))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{ namespace }}` }}",
+              "legendFormat": "{{`{{ namespace }}`}}",
+              "range": true,
               "refId": "A"
             }
           ],
           "thresholds": [],
+          "timeRegions": [],
           "title": "CPU Use of node",
           "tooltip": {
             "shared": false,
@@ -2488,11 +2748,13 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1205",
               "format": "percent",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:1206",
               "format": "short",
               "logBase": 1,
               "show": false
@@ -2509,17 +2771,19 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "decimals": 2,
           "description": "Cluster CPU capacity in real time",
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
             "y": 51
           },
+          "hiddenSeries": false,
           "id": 10,
           "legend": {
             "alignAsTable": false,
@@ -2536,8 +2800,11 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2547,28 +2814,51 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kube_node_status_capacity_cpu_cores)",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_node_status_capacity{resource=\"cpu\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "capacity",
+              "range": true,
               "refId": "A"
             },
             {
-              "expr": "sum(kube_node_status_allocatable_cpu_cores)",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "allocatable",
+              "range": true,
               "refId": "B"
             },
             {
-              "expr": "sum(kube_pod_container_resource_requests_cpu_cores)",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "requested",
+              "range": true,
               "refId": "C"
             },
             {
-              "expr": "SUM(irate(container_cpu_usage_seconds_total{id=\"/\"}[2m]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "SUM(irate(container_cpu_usage_seconds_total[2m]))",
               "format": "time_series",
               "instant": false,
               "interval": "10s",
@@ -2578,6 +2868,7 @@ data:
             }
           ],
           "thresholds": [],
+          "timeRegions": [],
           "title": "Cluster CPU Capacity",
           "tooltip": {
             "shared": true,
@@ -2592,12 +2883,14 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:520",
               "format": "none",
               "label": "cores",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:521",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -2610,7 +2903,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Percent of use of Ram Memory resource request in the Cluster",
           "fieldConfig": {
@@ -2673,12 +2966,18 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "max(sum(kube_pod_container_resource_requests_memory_bytes) by (instance)) / min(sum(kube_node_status_allocatable_memory_bytes) by (instance)) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "max(sum(kube_pod_container_resource_requests{resource=\"memory\"}) by (instance)) / min(sum(kube_node_status_allocatable{resource=\"memory\"}) by (instance)) * 100",
               "format": "time_series",
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -2688,7 +2987,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Percent of use of Ram Memory resource limit in the Cluster",
           "fieldConfig": {
@@ -2751,12 +3050,18 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "max(sum(kube_pod_container_resource_limits_memory_bytes) by (instance)) / min(sum(kube_node_status_allocatable_memory_bytes) by (instance)) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "max(sum(kube_pod_container_resource_limits{resource=\"memory\"}) by (instance)) / min(sum(kube_node_status_allocatable{resource='memory'}) by (instance)) * 100",
               "format": "time_series",
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -2766,7 +3071,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Use Ram memory Cluster",
           "fieldConfig": {
@@ -2827,10 +3132,15 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{id=\"/\",container_name!=\"POD\"})",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{container_name!=\"POD\"})",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -2847,17 +3157,19 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "decimals": 2,
           "description": "Ram memory Use of node by namespace",
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 12,
             "y": 58
           },
+          "hiddenSeries": false,
           "id": 62,
           "legend": {
             "alignAsTable": true,
@@ -2875,8 +3187,11 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2886,14 +3201,21 @@ data:
           "steppedLine": true,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{container_name!=\"\"}) by (namespace,container_name)",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(container_memory_usage_bytes{name!=\"\"}) by (node)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{ namespace }}` }}",
+              "legendFormat": "{{`{{ namespace }}`}}",
+              "range": true,
               "refId": "A"
             }
           ],
           "thresholds": [],
+          "timeRegions": [],
           "title": "Ram memory Use of node",
           "tooltip": {
             "shared": false,
@@ -2908,11 +3230,13 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:102",
               "format": "decbytes",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:103",
               "format": "short",
               "logBase": 1,
               "show": false
@@ -2929,16 +3253,18 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Cluster Ram memory capacity in real time",
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
             "y": 63
           },
+          "hiddenSeries": false,
           "id": 11,
           "legend": {
             "avg": false,
@@ -2953,8 +3279,11 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2964,29 +3293,55 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(min(sum(kube_node_status_allocatable_memory_bytes) by (instance)))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(min(sum(kube_node_status_allocatable{resource=\"memory\"}) by (instance)))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Allocatable Memory",
+              "range": true,
               "refId": "A"
             },
             {
-              "expr": "max(sum(kube_pod_container_resource_requests_memory_bytes) by (instance))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max(sum(kube_pod_container_resource_requests{resource=\"memory\"}) by (instance))",
               "format": "time_series",
+              "instant": false,
               "intervalFactor": 2,
               "legendFormat": "Requested Memory",
+              "range": true,
               "refId": "B"
             },
             {
-              "expr": "max(sum(kube_pod_container_resource_limits_memory_bytes) by (instance))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "max(sum(kube_pod_container_resource_limits{resource=\"memory\"}) by (instance))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Limits Memory",
+              "range": true,
               "refId": "C"
             },
             {
-              "expr": "sum(container_memory_working_set_bytes{id=\"/\",container_name!=\"POD\"})",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(container_memory_working_set_bytes{container_name!=\"POD\"})",
               "format": "time_series",
+              "hide": false,
               "instant": false,
               "intervalFactor": 1,
               "legendFormat": "Currentusage",
@@ -2994,6 +3349,7 @@ data:
             }
           ],
           "thresholds": [],
+          "timeRegions": [],
           "title": "Cluster Ram memory Capacity",
           "tooltip": {
             "shared": true,
@@ -3008,12 +3364,14 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:819",
               "decimals": 1,
               "format": "decbytes",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:820",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -3025,7 +3383,7 @@ data:
         }
       ],
       "refresh": "1m",
-      "schemaVersion": 34,
+      "schemaVersion": 37,
       "style": "dark",
       "tags": [
         "kubernetes",
@@ -3045,8 +3403,9 @@ data:
             "name": "cluster",
             "options": [],
             "query": "prometheus",
+            "queryValue": "",
             "refresh": 1,
-            "regex": "",
+            "regex": "/$ds/",
             "skipUrlSync": false,
             "type": "datasource"
           },
@@ -3057,11 +3416,7 @@ data:
               "text": "None",
               "value": ""
             },
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "definition": "",
+            "definition": "datasource",
             "hide": 2,
             "includeAll": false,
             "label": "",
@@ -3070,7 +3425,7 @@ data:
             "options": [],
             "query": {
               "query": "datasource",
-              "refId": "Prometheus-ds-Variable-Query"
+              "refId": "StandardVariableQuery"
             },
             "refresh": 1,
             "regex": "",
@@ -3105,11 +3460,7 @@ data:
               "text": "All",
               "value": "$__all"
             },
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "definition": "",
+            "definition": "label_values(node_boot_time{job=\"node-exporter\"}, instance)",
             "hide": 0,
             "includeAll": true,
             "multi": true,
@@ -3117,7 +3468,7 @@ data:
             "options": [],
             "query": {
               "query": "label_values(node_boot_time{job=\"node-exporter\"}, instance)",
-              "refId": "Prometheus-node-Variable-Query"
+              "refId": "StandardVariableQuery"
             },
             "refresh": 1,
             "regex": "",
@@ -3131,10 +3482,6 @@ data:
               "selected": false,
               "text": "All",
               "value": "$__all"
-            },
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
             },
             "definition": "",
             "hide": 0,
@@ -3186,7 +3533,7 @@ data:
       },
       "timezone": "browser",
       "title": "K8s Cluster Metrics",
-      "uid": "taQlRuxik",
-      "version": 1,
+      "uid": "77920b77e01e60227d098a3574130a0c31a29915",
+      "version": 11,
       "weekStart": ""
     }


### PR DESCRIPTION
Fixed missing kube-related metrics:  Please see ticket for extended details.

# Dashboard can be seen in GSTG1 here:
https://grafana.b-gstg1.govpreprod.bluescape.io/d/77920b77e01e60227d098a3574130a0c31a29915/k8s-cluster-metrics