### PR TITLE
NEX-3045 - Importing `raw` chart

### DIFF
--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: raw
+description: A place for all the Kubernetes resources which don't already have a home
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0-alpha1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: 1.0.0-alpha1
+
+

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-alpha1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.0.0-alpha1
+appVersion: 1.0.0
 
 

--- a/charts/raw/README.md
+++ b/charts/raw/README.md
@@ -1,0 +1,60 @@
+# itscontained/raw
+
+The `itscontained/raw` chart takes a list of Kubernetes resources and
+merges each resource with a default `metadata.labels` map and installs
+the result.
+
+The Kubernetes resources can be "raw" ones defined under the `resources` key, or "templated" ones defined under the `templates` key.
+
+Some use cases for this chart include Helm-based installation and
+maintenance of resources of kinds:
+- LimitRange
+- PriorityClass
+- Secret
+
+## Usage
+
+### Raw resources
+
+#### STEP 1: Create a yaml file containing your raw resources.
+
+```
+# raw-priority-classes.yaml
+resources:
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: common-critical
+    value: 100000000
+    globalDefault: false
+    description: "This priority class should only be used for critical priority common pods."
+```
+
+#### STEP 2: Install your raw resources.
+
+```
+helm install raw-priority-classes itscontained/raw -f raw-priority-classes.yaml
+```
+
+### Templated resources
+
+#### STEP 1: Create a yaml file containing your templated resources.
+
+```
+# values.yaml
+
+templates:
+- |
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: common-secret
+  stringData:
+    mykey: {{ .Values.mysecret }}
+```
+
+#### STEP 2: Install your templated resources.
+
+```
+helm install mysecret itscontained/raw -f values.yaml
+```

--- a/charts/raw/templates/_helpers.tpl
+++ b/charts/raw/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "raw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "raw.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "raw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+raw.resource will create a resource template that can be
+merged with each item in `.Values.resources`.
+*/}}
+{{- define "raw.resource" -}}
+metadata:
+  labels:
+    app: {{ template "raw.name" . }}
+    chart: {{ template "raw.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/charts/raw/templates/resources.yaml
+++ b/charts/raw/templates/resources.yaml
@@ -1,0 +1,9 @@
+{{- $template := fromYaml (include "raw.resource" .) -}}
+{{- range .Values.resources }}
+---
+{{ toYaml (merge . $template) -}}
+{{- end }}
+{{- range $i, $t := .Values.templates }}
+---
+{{ toYaml (merge (tpl $t $ | fromYaml) $template) -}}
+{{- end }}

--- a/charts/raw/values.yaml
+++ b/charts/raw/values.yaml
@@ -1,0 +1,17 @@
+resources: []
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: app-low
+#    value: 70000
+#    globalDefault: false
+#    description: "This priority class should only be used for low priority app pods."
+
+templates: []
+#  - |
+#    apiVersion: v1
+#    kind: Secret
+#    metadata:
+#      name: common-secret
+#    stringData:
+#      mykey: {{ .Values.mysecret }}


### PR DESCRIPTION
Importing from https://artifacthub.io/packages/helm/itscontained/raw  

- The `raw` chart takes a list of Kubernetes resources and merges each resource with a default metadata.labels map and installs the result.
- The Kubernetes resources can be "raw" ones defined under the resources key, or "templated" ones defined under the templates key.

**TODO**
- Version to be bumped.  