### PR TITLE
New Chart version for istio-additions (0.2.6)

### DIFF
--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6-alpha1
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/Chart.yaml
+++ b/charts/istio-additions/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/istio-additions/values.yaml
+++ b/charts/istio-additions/values.yaml
@@ -45,7 +45,7 @@ kiali:
     image:
       override: false
       repository: quay.io/kiali/kiali
-      tag: v1.59.1
+      tag: v1.73.0
     ingress:
       enabled: false
       host: 'kiali.example.bluescape.io'
@@ -58,7 +58,7 @@ kiali:
     image:
       override: false
       repository: quay.io/kiali/kiali
-      tag: v1.59.1
+      tag: v1.73.0
     ingress:
       enabled: false
       host: 'kiali.example.bluescape.io'
@@ -73,13 +73,13 @@ jaeger:
     enabled: false
     image:
       repository: jaegertracing/all-in-one
-      tag: 1.39.0
+      tag: 1.49.0
     ingress:
       enabled: false
   prod_config:
     enabled: false
     image:
       repository: jaegertracing/all-in-one
-      tag: 1.39.0
+      tag: 1.49.0
     ingress:
       enabled: false


### PR DESCRIPTION
Version upgrade required for kiali/kiali-operator & jaeger/jaeger-operator to protect against bad source telemetry.

**Related to**
- https://github.com/Bluescape/infrastructure/pull/6914